### PR TITLE
Start setup of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+language: generic
+
+env:
+    global:
+        - PYTHONIOENCODING=UTF8
+        - MPLBACKEND=Agg
+
+matrix:
+  include:
+    - os: linux
+      language: generic
+      env:
+        - PYTHON_VERSION=3.6
+        - CONDA=true
+
+    - os: linux
+      language: generic
+      env:
+        - PYTHON_VERSION=3.7
+        - CONDA=true
+
+before_install:
+
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - . $HOME/miniconda/etc/profile.d/conda.sh
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda  # get latest conda version
+    - conda info -a # Useful for debugging any issues with conda
+
+install:
+    - conda env create -f environment.yml
+    - conda activate pyirf
+    - pip install travis-sphinx codecov pytest-cov
+    - python setup.py install
+
+script:
+    # - pytest --cov=protopipe
+    # - travis-sphinx -v --outdir=docs/_build build -n --source=docs/
+
+after_script:
+    - if [[ "$CONDA" == "true" ]];then
+          conda deactivate
+      fi
+
+after_success:
+    # - travis-sphinx -v --outdir=docs/_build deploy
+    # - codecov


### PR DESCRIPTION
This PR, related to #3 , adds a basic Travis CI configuration file.

The CI for the moment takes care only for installation of the environment and of _pyirf_ itself, but the rest (pytest, codecov, and building of the docs) can be simply un-commented as soon as the repository is set up properly.