### PR TITLE
Verify hdus using ogadf-schema

### DIFF
--- a/pyirf/io/tests/test_gadf.py
+++ b/pyirf/io/tests/test_gadf.py
@@ -105,7 +105,7 @@ def test_effective_area2d_schema(aeff2d_hdus):
     '''Test our effective area is readable by gammapy'''
     from ogadf_schema.irfs import AEFF_2D
 
-    area, hdus = aeff2d_hdus
+    _, hdus = aeff2d_hdus
 
     for hdu in hdus:
         AEFF_2D.validate_hdu(hdu)
@@ -130,7 +130,7 @@ def test_energy_dispersion_gammapy(edisp_hdus):
 def test_energy_dispersion_schema(edisp_hdus):
     from ogadf_schema.irfs import EDISP_2D
 
-    edisp, hdus = edisp_hdus
+    _, hdus = edisp_hdus
 
     for hdu in hdus:
         EDISP_2D.validate_hdu(hdu)
@@ -158,7 +158,7 @@ def test_psf_table_gammapy(psf_hdu):
 def test_psf_schema(psf_hdu):
     from ogadf_schema.irfs import PSF_TABLE
 
-    psf, hdu = psf_hdu
+    _, hdu = psf_hdu
     PSF_TABLE.validate_hdu(hdu)
 
 
@@ -185,12 +185,12 @@ def test_background_2d_gammapy(bg_hdu):
 def test_background_2d_schema(bg_hdu):
     from ogadf_schema.irfs import BKG_2D
 
-    bg, hdu = bg_hdu
+    _, hdu = bg_hdu
     BKG_2D.validate_hdu(hdu)
 
 
 def test_rad_max_schema(rad_max_hdu):
     from ogadf_schema.irfs import RAD_MAX
 
-    bg, hdu = rad_max_hdu
+    _, hdu = rad_max_hdu
     RAD_MAX.validate_hdu(hdu)

--- a/pyirf/io/tests/test_gadf.py
+++ b/pyirf/io/tests/test_gadf.py
@@ -75,6 +75,17 @@ def bg_hdu():
     return background, hdu
 
 
+@pytest.fixture
+def rad_max_hdu():
+    from pyirf.io import create_rad_max_hdu
+
+    rad_max = np.full((len(e_bins) - 1, len(fov_bins) - 1), 0.1) * u.deg
+    print(rad_max.shape)
+    hdu = create_rad_max_hdu(e_bins, fov_bins, rad_max)
+
+    return rad_max, hdu
+
+
 def test_effective_area2d_gammapy(aeff2d_hdus):
     '''Test our effective area is readable by gammapy'''
     pytest.importorskip('gammapy')
@@ -176,3 +187,10 @@ def test_background_2d_schema(bg_hdu):
 
     bg, hdu = bg_hdu
     BKG_2D.validate_hdu(hdu)
+
+
+def test_rad_max_schema(rad_max_hdu):
+    from ogadf_schema.irfs import RAD_MAX
+
+    bg, hdu = rad_max_hdu
+    RAD_MAX.validate_hdu(hdu)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "gammapy~=0.17",
-        "ogadf-schema~=0.2.4",
+        "ogadf-schema~=0.2.3",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ extras_require = {
         "nbsphinx",
         "uproot~=3.0",
     ],
-    "tests": ["pytest", "pytest-cov", "gammapy~=0.17"],
+    "tests": [
+        "pytest",
+        "pytest-cov",
+        "gammapy~=0.17",
+        "ogadf-schema~=0.2.4",
+    ],
 }
 
 extras_require["all"] = extras_require["tests"] + extras_require["docs"]


### PR DESCRIPTION
This adds tests verifying that the hdus created by `pyirf.io.gadf` are schema compliant to the GADF schemas using `ogadf-schema`