### PR TITLE
Fix download for password protected data

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,6 +19,8 @@ The resulting FITS files are the input to the example and can be downloaded usin
     ./download_test_data.sh
 
 This requires ``curl`` and ``unzip`` to be installed.
+The download is password protected, please ask one of the maintainers for the
+password.
 
 The example can then be run from the root of the repository after installing pyirf
 by running:

--- a/download_test_data.sh
+++ b/download_test_data.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-curl -sSfL -o data.zip https://nextcloud.e5.physik.tu-dortmund.de/index.php/s/Cstsf8MWZjnz92L/download
+set -eo pipefail
+
+if [ -z "$DATA_PASSWORD" ]; then
+	echo -n "Password: "
+	read -s DATA_PASSWORD
+	echo
+fi
+
+URL=https://nextcloud.e5.physik.tu-dortmund.de/public.php/webdav/
+
+curl -sSfL -o data.zip -u "pffcqqxsLbZPCc7:$DATA_PASSWORD" "$URL"
 unzip data.zip
 rm data.zip
-mv eventdisplay_dl2 data


### PR DESCRIPTION
The test data is now password protected, I added the password to the credentials on travis.

This script now asks for the password if the environment variable is not set.