### PR TITLE
Change argument order in create_rad_max_hdu

### DIFF
--- a/examples/calculate_eventdisplay_irfs.py
+++ b/examples/calculate_eventdisplay_irfs.py
@@ -286,7 +286,7 @@ def main():
             psf, true_energy_bins, source_offset_bins, fov_offset_bins,
     ))
     hdus.append(create_rad_max_hdu(
-            theta_bins, fov_offset_bins, rad_max=theta_cuts_opt["cut"][:, np.newaxis]
+            theta_cuts_opt["cut"][:, np.newaxis], theta_bins, fov_offset_bins
     ))
     hdus.append(fits.BinTableHDU(ang_res, name="ANGULAR_RESOLUTION"))
     hdus.append(fits.BinTableHDU(bias_resolution, name="ENERGY_BIAS_RESOLUTION"))

--- a/pyirf/io/gadf.py
+++ b/pyirf/io/gadf.py
@@ -276,15 +276,15 @@ def create_background_2d_hdu(
 
 
 @u.quantity_input(
+    rad_max=u.deg,
     reco_energy_bins=u.TeV,
     fov_offset_bins=u.deg,
-    rad_max=u.deg,
     source_offset_bins=u.deg,
 )
 def create_rad_max_hdu(
+    rad_max,
     reco_energy_bins,
     fov_offset_bins,
-    rad_max,
     point_like=True,
     extname="RAD_MAX",
     **header_cards,
@@ -296,14 +296,14 @@ def create_rad_max_hdu(
 
     Parameters
     ----------
+    rad_max: astropy.units.Quantity[angle]
+        Array of the directional (theta) cut.
+        Must have shape (n_reco_energy_bins, n_fov_offset_bins)
     reco_energy_bins: astropy.units.Quantity[energy]
         Bin edges in reconstructed energy
     fov_offset_bins: astropy.units.Quantity[angle]
         Bin edges in the field of view offset.
         For Point-Like IRFs, only giving a single bin is appropriate.
-    rad_max: astropy.units.Quantity[angle]
-        Array of the directional (theta) cut.
-        Must have shape (n_reco_energy_bins, n_fov_offset_bins)
     extname: str
         Name for BinTableHDU
     **header_cards

--- a/pyirf/io/gadf.py
+++ b/pyirf/io/gadf.py
@@ -279,7 +279,6 @@ def create_background_2d_hdu(
     rad_max=u.deg,
     reco_energy_bins=u.TeV,
     fov_offset_bins=u.deg,
-    source_offset_bins=u.deg,
 )
 def create_rad_max_hdu(
     rad_max,

--- a/pyirf/io/tests/test_gadf.py
+++ b/pyirf/io/tests/test_gadf.py
@@ -80,8 +80,7 @@ def rad_max_hdu():
     from pyirf.io import create_rad_max_hdu
 
     rad_max = np.full((len(e_bins) - 1, len(fov_bins) - 1), 0.1) * u.deg
-    print(rad_max.shape)
-    hdu = create_rad_max_hdu(e_bins, fov_bins, rad_max)
+    hdu = create_rad_max_hdu(rad_max, e_bins, fov_bins)
 
     return rad_max, hdu
 


### PR DESCRIPTION
Fixes a minor inconsistency in the call of `create_rad_max_hdu`.
See #57