### PR TITLE
added the IO functions removed from PR #141

### DIFF
--- a/pyirf/io/tests/test_gadf.py
+++ b/pyirf/io/tests/test_gadf.py
@@ -1,9 +1,10 @@
 '''
-Test export to GADF format
+Test export to / import from GADF format
 '''
 import astropy.units as u
 import numpy as np
 from astropy.io import fits
+from pyirf.io import gadf
 import pytest
 import tempfile
 
@@ -181,3 +182,79 @@ def test_rad_max_schema(rad_max_hdu):
 
     _, hdu = rad_max_hdu
     RAD_MAX.validate_hdu(hdu)
+
+
+def test_compare_irf_cuts_files():
+    """Test of cut consistency using real files: two same ones and one different."""
+    from pyirf.io.gadf import compare_irf_cuts_in_files
+    file1a = '../../../data/interp_test_data/pyirf_eventdisplay_68.fits.gz'
+    file1b = '../../../data/interp_test_data/pyirf_eventdisplay_68_copy.fits.gz'
+    file2 = '../../../data/interp_test_data/pyirf_eventdisplay_80.fits.gz'
+
+    assert compare_irf_cuts_in_files([file1a, file1b], 'THETA_CUTS')
+
+    assert compare_irf_cuts_in_files([file1a, file1b, file2], 'THETA_CUTS') is False
+
+def test_read_irf_cuts():
+    """Simple test of reading cuts from a file."""
+    from pyirf.io.gadf import read_irf_cuts
+    file1 = '../../../data/interp_test_data/pyirf_eventdisplay_68.fits.gz'
+    cuts = read_irf_cuts(file1)
+    # check if you get one set of cuts and the number of rows matches
+    assert len(cuts) == 1
+    assert cuts[0].as_array().shape==(212,)
+
+    # now for reading two files
+    cuts = read_irf_cuts([file1, file1])
+    assert len(cuts) == 2
+    assert cuts[1].as_array().shape==(212,)
+
+
+def test_read_fits_bins_lo_hi():
+    """Tests read_fits_bins_lo_hi on sample file."""
+    file_name = '../../../data/interp_test_data/pyirf_eventdisplay_68.fits.gz'
+    bin_lo, bin_hi = gadf.read_fits_bins_lo_hi(file_name, 'EFFECTIVE_AREA', 'ENERG')[0]
+
+    # check that the bins are not empty
+    assert len(bin_lo) > 0
+
+    # check if the right edge bin of one bin matches the start of the next one
+    # (allow for numerical precision of 1.e-5)
+    assert np.allclose(bin_lo[1:], bin_hi[:-1], rtol=1.e-5)
+
+
+def test_read_irf_grid():
+    """Tests read_irf_grid on a single file and on a list of files."""
+    file_name = '../../../data/interp_test_data/irf_file_prod3b-v2_North_z20_N_50h.fits'
+    extname = "EFFECTIVE AREA"
+    fname = "EFFAREA"
+    # check on a single file
+    aeff = gadf.read_irf_grid(file_name, extname=extname, field_name=fname)
+    assert aeff.shape == (6, 42)
+
+    # check on a list of files
+    aeff = gadf.read_irf_grid([file_name, file_name], extname=extname, field_name=fname)
+    assert aeff.shape == (2, 6, 42)
+
+
+def test_read_aeff2d_hdu():
+    """Test read_aeff2d_hdu function."""
+    file_name = '../../../data/interp_test_data/irf_file_prod3b-v2_North_z20_N_50h.fits'
+    aeff, e_bins, th_bins = gadf.read_aeff2d_hdu([file_name, file_name], extname="EFFECTIVE AREA")
+
+    # check if correct shapes are recovered from the file
+    assert aeff.shape == (2, 6, 42)
+    assert e_bins.shape == (43,)
+    assert th_bins.shape == (7,)
+
+
+def test_read_energy_dispersion_hdu():
+    """Test energy_dispersion_hdu function."""
+    file_name = '../../../data/interp_test_data/irf_file_prod3b-v2_North_z20_N_50h.fits'
+    edisp, e_bins, mig_bins, th_bins = gadf.read_energy_dispersion_hdu(file_name, extname="ENERGY DISPERSION")
+
+    # check if correct shapes are recovered from the file
+    assert edisp.shape == (500, 300, 6)
+    assert mig_bins.shape == (301,)
+    assert e_bins.shape == (501,)
+    assert th_bins.shape == (7,)


### PR DESCRIPTION
Since #141 is already merged, as announced there I moved into this separate PR the IO functions. 
the summary of the discussion with @maxnoe from the previous PR was that Max was not in favor of having functions that read arrays of IRFs, while I think this is very useful because it is not trivial as some transformations have to be done (separate lo/high bins vs a single list of bins, change of sequence of axes) and they are common in all the IRFs, so if not implemented this way, would result in quite some code repetition. There are some two generic functions in this PR: read_irf_grid and read_fits_bins_lo_hi that read in the actual IRFs (whatever type, including the transformation), and bins values (including their consistency), and two wrapper functions for Aeff and migration matrix. 

Please let me know of any modifications of those functions that you would like