### PR TITLE
Fill energy and/or angular resolution tables with NaNs if input events table is empty

### DIFF
--- a/pyirf/benchmarks/angular_resolution.py
+++ b/pyirf/benchmarks/angular_resolution.py
@@ -51,6 +51,11 @@ def angular_resolution(
 
     result["angular_resolution"] = np.nan * u.deg
 
+    if not len(events):
+        # if we get an empty input (no selected events available)
+        # we return the table filled with NaNs
+        return result
+
     # use groupby operations to calculate the percentile in each bin
     by_bin = table[mask].group_by("bin_index")
 

--- a/pyirf/benchmarks/energy_bias_resolution.py
+++ b/pyirf/benchmarks/energy_bias_resolution.py
@@ -88,7 +88,7 @@ def energy_bias_resolution(
     table["bin_index"] = calculate_bin_indices(
         table[f"{energy_type}_energy"].quantity, energy_bins
     )
-    n_bins =  len(energy_bins) - 1
+    n_bins = len(energy_bins) - 1
     mask = (table["bin_index"] >= 0) & (table["bin_index"] < n_bins)
 
     result = Table()
@@ -98,6 +98,11 @@ def energy_bias_resolution(
 
     result["bias"] = np.nan
     result["resolution"] = np.nan
+
+    if not len(events):
+        # if we get an empty input (no selected events available)
+        # we return the table filled with NaNs
+        return result
 
     # use groupby operations to calculate the percentile in each bin
     by_bin = table[mask].group_by("bin_index")

--- a/pyirf/benchmarks/tests/test_angular_resolution.py
+++ b/pyirf/benchmarks/tests/test_angular_resolution.py
@@ -3,6 +3,21 @@ import astropy.units as u
 import numpy as np
 
 
+def test_empty_bias_resolution():
+    from pyirf.benchmarks import angular_resolution
+
+    events = QTable({
+        'true_energy': [] * u.TeV,
+        '"theta"': [] * u.deg,
+    })
+
+    table = angular_resolution(
+        events,
+        [1, 10, 100] * u.TeV
+    )
+
+    assert np.all(np.isnan(table["angular_resolution"]))
+
 def test_angular_resolution():
     from pyirf.benchmarks import angular_resolution
 

--- a/pyirf/benchmarks/tests/test_angular_resolution.py
+++ b/pyirf/benchmarks/tests/test_angular_resolution.py
@@ -8,7 +8,7 @@ def test_empty_bias_resolution():
 
     events = QTable({
         'true_energy': [] * u.TeV,
-        '"theta"': [] * u.deg,
+        'theta': [] * u.deg,
     })
 
     table = angular_resolution(

--- a/pyirf/benchmarks/tests/test_angular_resolution.py
+++ b/pyirf/benchmarks/tests/test_angular_resolution.py
@@ -3,7 +3,7 @@ import astropy.units as u
 import numpy as np
 
 
-def test_empty_bias_resolution():
+def test_empty_angular_resolution():
     from pyirf.benchmarks import angular_resolution
 
     events = QTable({

--- a/pyirf/benchmarks/tests/test_bias_resolution.py
+++ b/pyirf/benchmarks/tests/test_bias_resolution.py
@@ -5,6 +5,22 @@ from scipy.stats import norm
 from itertools import product
 
 
+def test_empty_bias_resolution():
+    from pyirf.benchmarks import energy_bias_resolution
+
+    events = QTable({
+        'true_energy': [] * u.TeV,
+        'reco_energy': [] * u.TeV,
+    })
+
+    table = energy_bias_resolution(
+        events,
+        [1, 10, 100] * u.TeV
+    )
+
+    assert np.all(np.isnan(table["bias"]))
+    assert np.all(np.isnan(table["resolution"]))
+
 def test_energy_bias_resolution():
     from pyirf.benchmarks import energy_bias_resolution
 


### PR DESCRIPTION
Currently, in the unfortunate case of no selected DL2 events, if these functions are called a crash bug is triggered.

We should instead make sure that if they get an empty (but correctly defined) table, it is filled with NaNs and a correct output is always created.