### PR TITLE
Interpolate psf

### DIFF
--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -3,7 +3,7 @@
 import numpy as np
 import astropy.units as u
 from scipy.interpolate import griddata
-
+from pyirf.utils import cone_solid_angle
 
 __all__ = [
     'interpolate_effective_area_per_energy_and_fov',
@@ -138,7 +138,7 @@ def interpolate_psf_table(
         psf_interp = np.concatenate((psf_interp[...,:1], np.diff(psf_interp, axis=2)), axis=2)
 
     # now we need to renormalize along the source offset axis
-    omegas = 2 * np.pi * (np.cos(source_offset_bins[:-1]) - np.cos(source_offset_bins[1:])) * u.sr
+    omegas = np.diff(cone_solid_angle(source_offset_bins))
     norm = np.sum(psf_interp * omegas, axis=2, keepdims=True)
     # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
     psf_norm = np.divide(psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -95,3 +95,40 @@ def interpolate_energy_dispersion(
     return mig_norm
 
 
+def interpolate_psf_table(
+    psfs,
+    grid_points,
+    target_point,
+    method='linear',
+):
+    """
+    Takes a grid of PSF tables for a bunch of different parameters
+    and interpolates it to given value of those parameters
+
+    Parameters
+    ----------
+    psfs: np.ndarray
+        grid of PSF tables, of shape (n_grid_points, n_energy_bins, n_fov_offset_bins, n_source_offset_bins)
+    grid_points: np.ndarray
+        array of parameters corresponding to energy_dispersions, of shape (n_grid_points, n_interp_dim)
+    target_point: np.ndarray
+        values of parameters for which the interpolation is performed, of shape (n_interp_dim)
+    method: 'linear’, ‘nearest’, ‘cubic’
+        Interpolation method
+
+    Returns
+    -------
+    psf_interp: np.ndarray
+        Interpolated PSF table with shape (n_energy_bins,  n_fov_offset_bins, n_source_offset_bins)
+    """
+
+    # interpolation
+    psf_interp = griddata(grid_points, psfs, target_point, method=method)
+
+    # now we need to renormalize along the source offset axis
+    norm = np.sum(psf_interp, axis=2, keepdims=True)
+    # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
+    mig_norm = np.divide(psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0)
+    return mig_norm
+
+

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -111,6 +111,7 @@ def test_interpolate_energy_dispersion():
 @pytest.mark.parametrize("cumulative", [False, True])
 def test_interpolate_psf_table(cumulative):
     """Test of interpolation of PSF tables using a simple dummy model"""
+    from pyirf.utils import cone_solid_angle
     x = [0.9, 1.1]
     y = [8., 11.5]
     n_grid = len(x) * len(y)
@@ -125,7 +126,7 @@ def test_interpolate_psf_table(cumulative):
 
     en = np.arange(n_en)[:, np.newaxis, np.newaxis]
     src_bins = np.arange(n_src_off + 1) * u.deg
-    omegas = 2 * np.pi * (np.cos(src_bins[:-1]) - np.cos(src_bins[1:])) * u.sr
+    omegas = np.diff(cone_solid_angle(src_bins))
     src_off = np.arange(n_src_off)[np.newaxis, np.newaxis, :]
 
     # generate true values

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -1,7 +1,7 @@
 import pyirf.interpolation as interp
 import numpy as np
 import astropy.units as u
-
+import pytest
 
 def test_interpolate_effective_area_per_energy_and_fov():
     """Test of interpolating of effective area using dummy model files."""
@@ -108,8 +108,8 @@ def test_interpolate_energy_dispersion():
     assert np.allclose(bias, bias0, atol=0.6, rtol=0.)
     assert np.allclose(stds, stds0, atol=0.6, rtol=0.)
 
-
-def test_interpolate_psf_table():
+@pytest.mark.parametrize("cumulative", [False, True])
+def test_interpolate_psf_table(cumulative):
     """Test of interpolation of PSF tables using a simple dummy model"""
     x = [0.9, 1.1]
     y = [8., 11.5]
@@ -146,7 +146,7 @@ def test_interpolate_psf_table():
     psfs_all *= u.Unit('sr-1')
 
     # do the interpolation and compare the results with expected ones
-    psf_interp = interp.interpolate_psf_table(psfs_all, pars_all, interp_pars, src_bins, method='linear')
+    psf_interp = interp.interpolate_psf_table(psfs_all, pars_all, interp_pars, src_bins, cumulative=cumulative, method='linear')
 
     # check if all the energy bins have normalization 1 or 0 (can happen because of empty bins)
     sums = np.sum(psf_interp * omegas, axis=2)


### PR DESCRIPTION
a function to interpolate PSF tables. I made it in a similar style like the other two interpolation functions. One difference is that I added an option to  interpolate over cumulative distribution. In principle this could help in the binning is fine and thus event statistics are sparse. For the tests that I did I haven't seen any significant difference, but the performance might depend on a particular use case. The default is to interpolate over differential distribution (which is slightly simpler)

@maxnoe I incorporated your comments about solid cone function, please let me know if you have any further comments