### PR TITLE
Refactor hist normalization, remove assert from library code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,23 +50,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --tags
+        with:
+          fetch-depth: 0
 
-      - name: Download data
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install doc dependencies
+        run: |
+          sudo apt update --yes && sudo apt install --yes git build-essential pandoc curl graphviz
+          pip install -U pip setuptools wheel
+          pip install -e .[docs]
+          git describe --tags
+          python -c 'import pyirf; print(pyirf.__version__)'
+
+      - name: Download data and run example
         env:
           DATA_PASSWORD: ${{ secrets.DATA_PASSWORD }}
         run: |
           ./download_test_data.sh
+          python examples/calculate_eventdisplay_irfs.py
 
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "docs/"
-          pre-build-command: |
-            apt update --yes && apt install --yes git build-essential pandoc curl
-            pip install -U pip setuptools wheel sphinx
-            pip install -e '.[docs]'
-            python examples/calculate_eventdisplay_irfs.py
-          build-command: make html SPHINXOPTS="-W --keep-going -n --color -w /tmp/sphinx-log"
+      - name: Build docs
+        run: cd docs && make html SPHINXOPTS="-W --keep-going -n --color -j auto"
 
       - name: Deploy to gihub pages
         # only run on push to master

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -47,7 +47,7 @@ See the `GitHub tutorial on forks <https://docs.github.com/en/github/getting-sta
 #. Wait for review comments and then implement or discuss requested changes.
 
 
-We use `Travis CI <https://travis-ci.com/github/cta-observatory/pyirf>`__ to
+We use `Github Actions <https://github.com/cta-observatory/pyirf/actions?query=workflow%3ACI+branch%3Amaster>`__ to
 run the unit tests and documentation building automatically for every pull request.
 Passing unit tests and coverage of the changed code are required for all pull requests.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,10 +32,21 @@ If you want to work on pyirf itself, clone the repository and install the local
 copy of pyirf in development mode.
 
 The dependencies required to perform unit-testing and to build the documentation
-are defined in ``extras`` under ``tests`` and ``docs`` respectively
+are defined in ``extras`` under ``tests`` and ``docs`` respectively.
 
-These requirements can be enabled by installing the ``all`` extra:
+These requirements can also be enabled by installing the ``all`` extra:
 
 .. code-block:: bash
 
     pip install -e '.[all]'  # or [docs,tests] to install them separately
+
+
+You should isolate your pyirf development environment from the rest of your system.
+Either by using a virtual environment or by using ``conda`` environments.
+``pyirf`` provides a conda ``environment.yml``, that includes all dependencies:
+
+.. code-block:: bash
+
+   conda env create -f environment.yml
+   conda activate pyirf
+   pip install -e '.[all]'

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: pyirf
 
 channels:
   - default
+  - conda-forge
 dependencies:
   - python=3.7
   - numpy
@@ -17,14 +18,14 @@ dependencies:
   - pytest-cov
   # docs
   - numpydoc
+  - pytables
+  - nbsphinx
   - sphinx
   - sphinx_rtd_theme
+  - sphinx_automodapi
+  - uproot=4
+  - awkward=1
+  - gammapy=0.18
   - pip
-  - pytables
   - pip:
-    - nbsphinx
-    - sphinx_automodapi
-    - uproot
-    - awkward1
-    - gammapy
     - ogadf_schema

--- a/pyirf/irf/psf.py
+++ b/pyirf/irf/psf.py
@@ -17,7 +17,7 @@ def psf_table(events, true_energy_bins, source_offset_bins, fov_offset_bins):
         ]
     )
 
-    hist, edges = np.histogramdd(
+    hist, _ = np.histogramdd(
         array,
         [
             true_energy_bins.to_value(u.TeV),
@@ -37,15 +37,9 @@ def _normalize_psf(hist, source_offset_bins):
     # ignore numpy zero division warning
     with np.errstate(invalid="ignore"):
 
-        # to correctly divide by using broadcasting here,
-        # we need to swap the axis order
-        n_events = hist.sum(axis=2).T
-        hist = np.swapaxes(hist, 0, 2)
-
+        # normalize over the theta axis
+        n_events = hist.sum(axis=2)
         # normalize and replace nans with 0
-        psf = np.nan_to_num(hist / n_events)
-
-        # swap axes back to order required by GADF
-        psf = np.swapaxes(psf, 0, 2)
+        psf = np.nan_to_num(hist / n_events[:, :, np.newaxis])
 
     return psf / solid_angle

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import os
 
 
-gammapy = "gammapy~=0.18"
+gammapy = "gammapy~=0.18.0"
 
 extras_require = {
     "docs": [
@@ -20,7 +20,7 @@ extras_require = {
     "tests": [
         "pytest",
         "pytest-cov",
-        "gammapy~=0.18",
+        gammapy,
         "ogadf-schema~=0.2.3",
         "uproot~=4.0",
         "awkward~=1.0",


### PR DESCRIPTION
I saw we had a defensive assert in the actual code, which is actually covered by the unit tests.

I also found a more understandable way of doing the normalization than this swapaxes stuff.