### PR TITLE
Replace outdated link to redmine by xwiki link

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -23,7 +23,7 @@ The download is password protected, please ask one of the maintainers for the
 password.
 
 A detailed explanation of the contents of such DL2 files can be found
-`here (internal) <https://forge.in2p3.fr/login?back_url=https%3A%2F%2Fforge.in2p3.fr%2Fprojects%2Fcta_analysis-and-simulations%2Fwiki%2FEventdisplay_Prod3b_DL2_Lists>`_.
+`here (internal) <https://cta.cloud.xwiki.com/xwiki/wiki/aswg/view/Main/Eventdisplay%20Prod3b%20DL2%20Lists/>`_.
 
 The example can then be run from the root of the repository after installing pyirf
 by running:


### PR DESCRIPTION
(super minor)