### PR TITLE
Adapted quantile interpolation

### DIFF
--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -145,10 +145,10 @@ def norm_pdf(pdf_values):
     """
     norm = np.sum(pdf_values, axis=-1)
 
-    # Ignore errors from rows without errors as they are set to 0 through nan_to_num
-    with np.errstate(invalid="ignore"):
-        normed_pdf_values = pdf_values / norm[..., np.newaxis]
-    return np.nan_to_num(normed_pdf_values)
+    # Norm all binned_pdfs to unity that are not empty
+    normed_pdf_values = np.divide(pdf_values, norm[..., np.newaxis], out=np.zeros_like(pdf_values), where=norm[..., np.newaxis] != 0)
+
+    return normed_pdf_values
 
 
 def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resolution):
@@ -218,7 +218,7 @@ def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resoluti
     normed_interpolated_pdfs = norm_pdf(interpolated_pdfs)
 
     # Re-swap axes and set all nans to zero
-    return np.swapaxes(normed_interpolated_pdfs, axis, -1)
+    return np.swapaxes(np.nan_to_num(normed_interpolated_pdfs), axis, -1)
 
 
 @u.quantity_input(effective_area=u.m ** 2)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -55,8 +55,8 @@ def ppf_values(cdfs, edges, quantiles):
         """
 
         # Find last 0 and first 1 entry
-        last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
-        first_1 = np.min(np.arange(len(cdf))[cdf == 1])
+        last_0 = np.nonzero(cdf == 0)[0][-1] if cdf[0] == 0 else 0
+        first_1 = np.nonzero(cdf == 1.0)[0][0]
 
         # Predefine selection mask
         selection = np.ones(len(cdf), dtype=bool)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -2,22 +2,23 @@
 
 import numpy as np
 import astropy.units as u
-from scipy.interpolate import griddata
+from scipy.interpolate import interp1d, griddata
 from pyirf.utils import cone_solid_angle
+from pyirf.binning import bin_center
 
 __all__ = [
-    'interpolate_effective_area_per_energy_and_fov',
-    'interpolate_energy_dispersion',
+    "interpolate_effective_area_per_energy_and_fov",
+    "interpolate_energy_dispersion",
 ]
 
 
-@u.quantity_input(effective_area=u.m**2)
+@u.quantity_input(effective_area=u.m ** 2)
 def interpolate_effective_area_per_energy_and_fov(
     effective_area,
     grid_points,
     target_point,
-    min_effective_area=1. * u.Unit('m2'),
-    method='linear',
+    min_effective_area=1.0 * u.Unit("m2"),
+    method="linear",
 ):
     """
     Takes a grid of effective areas for a bunch of different parameters
@@ -43,8 +44,8 @@ def interpolate_effective_area_per_energy_and_fov(
     """
 
     # get rid of units
-    effective_area = effective_area.to_value(u.m**2)
-    min_effective_area = min_effective_area.to_value(u.m**2)
+    effective_area = effective_area.to_value(u.m ** 2)
+    min_effective_area = min_effective_area.to_value(u.m ** 2)
 
     # remove zeros and log it
     effective_area[effective_area < min_effective_area] = min_effective_area
@@ -54,45 +55,130 @@ def interpolate_effective_area_per_energy_and_fov(
     aeff_interp = griddata(grid_points, effective_area, target_point, method=method).T
     # exp it and set to zero too low values
     aeff_interp = np.exp(aeff_interp)
-    aeff_interp[aeff_interp < min_effective_area * 1.1] = 0  # 1.1 to correct for numerical uncertainty and interpolation
-    return u.Quantity(aeff_interp, u.m**2, copy=False)
+    aeff_interp[
+        aeff_interp < min_effective_area * 1.1
+    ] = 0  # 1.1 to correct for numerical uncertainty and interpolation
+    return u.Quantity(aeff_interp, u.m ** 2, copy=False)
 
 
 def interpolate_energy_dispersion(
-    energy_dispersions,
-    grid_points,
-    target_point,
-    method='linear',
+    edges, hists, m, mprime, axis, quantile_resolution=1e-3
 ):
     """
     Takes a grid of dispersion matrixes for a bunch of different parameters
-    and interpolates it to given value of those parameters
+    and interpolates it to given value of those parameters.
+    This function provides an adapted version of the quantile Interpolation introduced
+    in [1].
+    Instead of following this method closely, it implements different approaches to the
+    steps shown in Fig. 5 of [1].
 
     Parameters
     ----------
-    energy_dispersions: np.ndarray
-        grid of energy migrations, of shape (n_grid_points, n_energy_bins, n_migration_bins, n_fov_offset_bins)
-    grid_points: np.ndarray
-        array of parameters corresponding to energy_dispersions, of shape (n_grid_points, n_interp_dim)
-    target_point: np.ndarray
-        values of parameters for which the interpolation is performed, of shape (n_interp_dim)
-    method: 'linear’, ‘nearest’, ‘cubic’
-        Interpolation method
+    edges: numpy.ndarray, shape=(M+1)
+        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
+
+    hists: numpy.ndarray, shape=(N,...,M,...)
+        Array of M bin-heights (along the ordinate ("y") axis) for each of the 2 input templates.
+        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
+        be given at the dimension specified by axis.
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's qunatiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    axis: int
+        Axis along which the pdfs used for interpolation are located
+
+    quantile_resolution: float
+        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
 
     Returns
     -------
-    matrix_interp: np.ndarray
-        Interpolated dispersion matrix 3D array with shape (n_energy_bins, n_migration_bins, n_fov_offset_bins)
+    f_new: numpy.ndarray, shape=(1,...,M,...)
+        Interpolated histograms
+
+    References
+    ----------
+    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
+           for Ensemble Visualization
+           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
     """
+    if hists.ndim > 2:
+        # To have the needed axis always at the last index, as the number of indices is
+        # not safely propageted through the interpolation but the last element remains the last element
+        hists = np.swapaxes(hists, axis, -1)
 
-    # interpolation
-    matrix_interp = griddata(grid_points, energy_dispersions, target_point, method=method)
+    # Compute CDFs
+    cdfs = np.cumsum(hists, axis=-1)
 
-    # now we need to renormalize along the migration axis
-    norm = np.sum(matrix_interp, axis=1, keepdims=True)
-    # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
-    mig_norm = np.divide(matrix_interp, norm, out=np.zeros_like(matrix_interp), where=norm != 0)
-    return mig_norm
+    cdfs = cdfs / np.expand_dims(np.max(cdfs, axis=-1), axis=-1)
+
+    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
+
+    bin_mids = bin_center(edges)
+
+    # create ppf values from cdf samples via interpolation of the cdfs, determine quantile steps of [1]
+    ppfs_resampled = np.apply_along_axis(
+        lambda cdf: interp1d(
+            cdf, bin_mids, bounds_error=False, fill_value="extrapolate"
+        )(quantiles),
+        -1,
+        cdfs,
+    )
+
+    # nD interpolation of ppf values, interpolate quantiles step of [1]
+    ppf_interpolant = griddata(m, ppfs_resampled, mprime)
+
+    # recalculate pdf values, evaluate interpolant PDF values step of [1]
+    pdf_interpolant = np.diff(quantiles) / np.diff(ppf_interpolant, axis=-1)
+
+    if hists.ndim > 2:
+        # Unconventional solution to make this usable with np.apply_along_axis for readability
+        # The ppf bin-mids are computed since the pdf-values are derived through derivation
+        # from the ppf-values
+        xyconcat = np.concatenate(
+            (
+                ppf_interpolant[..., :-1] + np.diff(ppf_interpolant) / 2,
+                np.nan_to_num(pdf_interpolant),
+            ),
+            axis=-1,
+        )
+
+        # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
+        # correct bin height via the midpoint rule formulation of the trapezoidal rule
+        result = np.apply_along_axis(
+            lambda xy: np.diff(edges)
+            * np.nan_to_num(
+                interp1d(
+                    xy[: int(len(xy) / 2)],
+                    xy[int(len(xy) / 2) :],
+                    bounds_error=False,
+                    fill_value=(0, 0),
+                )(bin_mids)
+            ),
+            -1,
+            xyconcat,
+        )
+
+        # Renormalize histogram to a sum of 1
+        norm = np.sum(result, axis=-1)
+        norm = np.repeat(np.expand_dims(norm, -1), result.shape[-1], axis=-1)
+        norm[norm == 0] = np.nan
+
+        return np.swapaxes(np.nan_to_num(result / norm), axis, -1)
+    else:
+        # Same as above, only simpler as only one axis exists
+        result = interp1d(
+            bin_center(ppf_interpolant.squeeze()),
+            np.nan_to_num(pdf_interpolant.squeeze()),
+            bounds_error=False,
+            fill_value=0,
+        )(bin_mids)
+        result = np.diff(edges) * result
+        return np.nan_to_num(result / np.sum(result))
 
 
 def interpolate_psf_table(
@@ -101,7 +187,7 @@ def interpolate_psf_table(
     target_point,
     source_offset_bins,
     cumulative=False,
-    method='linear',
+    method="linear",
 ):
     """
     Takes a grid of PSF tables for a bunch of different parameters
@@ -132,14 +218,20 @@ def interpolate_psf_table(
     if cumulative:
         psfs = np.cumsum(psfs, axis=3)
 
-    psf_interp = griddata(grid_points, psfs.to_value('sr-1'), target_point, method=method) * u.Unit('sr-1')
+    psf_interp = griddata(
+        grid_points, psfs.to_value("sr-1"), target_point, method=method
+    ) * u.Unit("sr-1")
 
     if cumulative:
-        psf_interp = np.concatenate((psf_interp[...,:1], np.diff(psf_interp, axis=2)), axis=2)
+        psf_interp = np.concatenate(
+            (psf_interp[..., :1], np.diff(psf_interp, axis=2)), axis=2
+        )
 
     # now we need to renormalize along the source offset axis
     omegas = np.diff(cone_solid_angle(source_offset_bins))
     norm = np.sum(psf_interp * omegas, axis=2, keepdims=True)
     # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
-    psf_norm = np.divide(psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0)
+    psf_norm = np.divide(
+        psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0
+    )
     return psf_norm

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -54,8 +54,6 @@ def ppf_values(cdfs, edges, quantiles):
         the interpolation polynom.
         """
 
-        # cdf = np.append(np.array(0), cdf)
-
         # Find last 0 and first 1 entry
         last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
         first_1 = np.min(np.arange(len(cdf))[cdf == 1])

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -12,6 +12,221 @@ __all__ = [
 ]
 
 
+def cdf_values(binned_pdf):
+    """
+    Compute cdf values and assure they are normed to unity
+    """
+    cdfs = np.cumsum(binned_pdf, axis=-1)
+
+    # assure the last cdf value is 1, ignore errors for empty pdfs as they are reset to 0 by nan_to_num
+    with np.errstate(invalid="ignore"):
+        cdfs = np.nan_to_num(cdfs / np.max(cdfs, axis=-1)[..., np.newaxis])
+
+    return cdfs
+
+
+def ppf_values(cdfs, bin_mids, m, mprime, quantiles):
+    """
+    Compute ppfs from cdfs and interpolate them to the desired interpolation point
+
+    Parameters
+    ----------
+    cdfs: numpy.ndarray, shape=(N,...,M)
+        Corresponding cdf-values for all quantiles
+
+    bin_mids: numpy.ndarray, shape=(M)
+        M bin-midss for which the cdf-values are known
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's quantiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    quantiles: numpy.ndarray, shape=(L)
+        L quantiles for which the ppf_values are known
+
+    Returns
+    -------
+    ppfs: numpy.ndarray, shape=(1,...,L)
+        Corresponding ppf-values for all quantiles at the target interpolation point
+    """
+
+    def cropped_interp(cdf):
+        """
+        create ppf-values through inverse interpolation of the cdf, avoiding repeating 0 and 1 entries
+        around the first and last bins as well as repeating values due to zero bins
+        in between filled bins. Both cases would result in division by zero errors when computing
+        the interpolation polynom.
+        """
+        # Find last 0 and first 1 entry
+        last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
+        first_1 = np.min(np.arange(len(cdf))[cdf == 1])
+
+        # Predefine selection mask
+        selection = np.ones(len(cdf), dtype=bool)
+
+        # Keep only the first of subsequently matching values
+        selection[1:] = cdf[1:] != cdf[:-1]
+
+        # Keep only the last 0 and first 1 entry
+        selection[:last_0] = False
+        selection[last_0] = True
+        selection[first_1 + 1 :] = False
+        selection[first_1] = True
+
+        # create ppf values from selected bins
+        return interp1d(
+            cdf[selection],
+            bin_mids[selection],
+            bounds_error=False,
+            fill_value="extrapolate",
+        )(quantiles)
+
+    # create ppf values from cdf samples via interpolation of the cdfs
+    # return nan for empty pdfs
+    ppfs = np.apply_along_axis(
+        lambda cdf: cropped_interp(cdf)
+        if np.sum(cdf) > 0
+        else np.full_like(quantiles, np.nan),
+        -1,
+        cdfs,
+    )
+    # nD interpolation of ppf values
+    return griddata(m, ppfs, mprime)
+
+
+def reconstruct_pdf_values(quantiles, ppfs, edges):
+    """
+    Reconstruct pdf from ppf and evaluate at desired points.
+
+    Parameters
+    ----------
+    quantiles: numpy.ndarray, shape=(L)
+        L quantiles for which the ppf_values are known
+
+    ppfs: numpy.ndarray, shape=(1,...,L)
+        Corresponding ppf-values for all quantiles
+
+    edges: numpy.ndarray, shape=(M+1)
+        Binning of the desired binned pdf
+
+    Returns
+    -------
+    pdf_values: numpy.ndarray, shape=(1,...,M)
+        Recomputed, binned pdf
+    """
+    # recalculate pdf values through numerical differentiation
+    pdf_interpolant = np.nan_to_num(np.diff(quantiles) / np.diff(ppfs, axis=-1))
+
+    # Unconventional solution to make this usable with np.apply_along_axis for readability
+    # The ppf bin-mids are computed since the pdf-values are derived through derivation
+    # from the ppf-values
+    xyconcat = np.concatenate(
+        (ppfs[..., :-1] + np.diff(ppfs) / 2, pdf_interpolant), axis=-1
+    )
+
+    # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
+    # correct bin height via the midpoint rule formulation of the trapezoidal rule
+    pdf_values = np.apply_along_axis(
+        lambda xy: np.diff(edges)
+        * np.nan_to_num(
+            interp1d(
+                xy[: int(len(xy) / 2)],
+                xy[int(len(xy) / 2) :],
+                bounds_error=False,
+                fill_value=(0, 0),
+            )(edges[:-1])
+        ),
+        -1,
+        xyconcat,
+    )
+
+    return pdf_values
+
+
+def norm_pdf(pdf_values):
+    """
+    Normalize binned_pdf to a sum of 1
+    """
+    norm = np.sum(pdf_values, axis=-1)
+
+    # Ignore errors from rows without errors as they are set to 0 through nan_to_num
+    with np.errstate(invalid="ignore"):
+        normed_pdf_values = pdf_values / norm[..., np.newaxis]
+    return np.nan_to_num(normed_pdf_values)
+
+
+def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resolution):
+    """
+    Takes a grid of binned pdfs for a bunch of different parameters
+    and interpolates it to given value of those parameters.
+    This function provides an adapted version of the quantile interpolation introduced
+    in [1].
+    Instead of following this method closely, it implements different approaches to the
+    steps shown in Fig. 5 of [1].
+
+    Parameters
+    ----------
+    edges: numpy.ndarray, shape=(M+1)
+        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
+
+    binned_pdf: numpy.ndarray, shape=(N,...,M,...)
+        Array of M bin-heights (along the ordinate ("y") axis) for each of the N input templates.
+        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
+        be given at the dimension specified by axis.
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's quantiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    axis: int
+        Axis along which the pdfs used for interpolation are located
+
+    quantile_resolution: float
+        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
+
+    Returns
+    -------
+    f_new: numpy.ndarray, shape=(1,...,M,...)
+        Interpolated and binned pdf
+
+    References
+    ----------
+    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
+           for Ensemble Visualization
+           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
+    """
+    # To have the needed axis always at the last index, as the number of indices is
+    # not safely propageted through the interpolation but the last element remains the last element
+    binned_pdf = np.swapaxes(binned_pdf, axis, -1)
+
+    # compute quantiles from quantile_resolution
+    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
+
+    # compute bin-mids from bin-edges
+    bin_mids = bin_center(edges)
+
+    # compute cdf values
+    cdfs = cdf_values(binned_pdf)
+
+    # compute ppf values at interpolation point, determine quantile and interpolate quantiles steps of [1]
+    ppfs = ppf_values(cdfs, bin_mids, m, mprime, quantiles)
+
+    # compute pdf values for all bins, evaluate interpolant PDF values step of [1]
+    pdf_values = reconstruct_pdf_values(quantiles, ppfs, edges)
+
+    # Renormalize pdf
+    normed_pdf_values = norm_pdf(pdf_values)
+
+    # Re-swap axes
+    return np.swapaxes(normed_pdf_values, axis, -1)
+
+
 @u.quantity_input(effective_area=u.m ** 2)
 def interpolate_effective_area_per_energy_and_fov(
     effective_area,
@@ -62,111 +277,15 @@ def interpolate_effective_area_per_energy_and_fov(
 
 
 def interpolate_energy_dispersion(
-    edges, hists, m, mprime, axis, quantile_resolution=1e-3
+    edges, binned_pdf, m, mprime, axis, quantile_resolution=1e-3
 ):
     """
-    Takes a grid of dispersion matrixes for a bunch of different parameters
+    Takes a grid of energy dispersions for a bunch of different parameters
     and interpolates it to given value of those parameters.
-    This function provides an adapted version of the quantile Interpolation introduced
-    in [1].
-    Instead of following this method closely, it implements different approaches to the
-    steps shown in Fig. 5 of [1].
-
-    Parameters
-    ----------
-    edges: numpy.ndarray, shape=(M+1)
-        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
-
-    hists: numpy.ndarray, shape=(N,...,M,...)
-        Array of M bin-heights (along the ordinate ("y") axis) for each of the 2 input templates.
-        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
-        be given at the dimension specified by axis.
-
-    m: numpy.ndarray, shape=(N, O)
-        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's qunatiles
-        are expected to vary linearly between these two reference points.
-
-    m_prime: numpy.ndarray, shape=(O)
-        Value for which the interpolation is performed (target point)
-
-    axis: int
-        Axis along which the pdfs used for interpolation are located
-
-    quantile_resolution: float
-        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
-
-    Returns
-    -------
-    f_new: numpy.ndarray, shape=(1,...,M,...)
-        Interpolated histograms
-
-    References
-    ----------
-    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
-           for Ensemble Visualization
-           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
     """
-    # To have the needed axis always at the last index, as the number of indices is
-    # not safely propageted through the interpolation but the last element remains the last element
-    hists = np.swapaxes(hists, axis, -1)
-
-    # Compute CDFs
-    cdfs = np.cumsum(hists, axis=-1)
-
-    cdfs = cdfs / np.expand_dims(np.max(cdfs, axis=-1), axis=-1)
-
-    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
-
-    bin_mids = bin_center(edges)
-
-    # create ppf values from cdf samples via interpolation of the cdfs, determine quantile steps of [1]
-    ppfs_resampled = np.apply_along_axis(
-        lambda cdf: interp1d(
-            cdf, bin_mids, bounds_error=False, fill_value="extrapolate"
-        )(quantiles),
-        -1,
-        cdfs,
+    return interpolate_binned_pdf(
+        edges, binned_pdf, m, mprime, axis, quantile_resolution
     )
-
-    # nD interpolation of ppf values, interpolate quantiles step of [1]
-    ppf_interpolant = griddata(m, ppfs_resampled, mprime)
-
-    # recalculate pdf values, evaluate interpolant PDF values step of [1]
-    pdf_interpolant = np.diff(quantiles) / np.diff(ppf_interpolant, axis=-1)
-
-    # Unconventional solution to make this usable with np.apply_along_axis for readability
-    # The ppf bin-mids are computed since the pdf-values are derived through derivation
-    # from the ppf-values
-    xyconcat = np.concatenate(
-        (
-            ppf_interpolant[..., :-1] + np.diff(ppf_interpolant) / 2,
-            np.nan_to_num(pdf_interpolant),
-        ),
-        axis=-1,
-    )
-
-    # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
-    # correct bin height via the midpoint rule formulation of the trapezoidal rule
-    result = np.apply_along_axis(
-        lambda xy: np.diff(edges)
-        * np.nan_to_num(
-            interp1d(
-                xy[: int(len(xy) / 2)],
-                xy[int(len(xy) / 2) :],
-                bounds_error=False,
-                fill_value=(0, 0),
-            )(bin_mids)
-        ),
-        -1,
-        xyconcat,
-    )
-
-    # Renormalize histogram to a sum of 1
-    norm = np.sum(result, axis=-1)
-    norm = np.repeat(np.expand_dims(norm, -1), result.shape[-1], axis=-1)
-    norm[norm == 0] = np.nan
-
-    return np.swapaxes(np.nan_to_num(result / norm), axis, -1)
 
 
 def interpolate_psf_table(

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -2,6 +2,132 @@ import pyirf.interpolation as interp
 import numpy as np
 import astropy.units as u
 import pytest
+from scipy.stats import norm
+from scipy.integrate import quad
+
+
+@pytest.fixture
+def data():
+    """Create common dataset containing binned Gaussians for interpolation testing. Binned PDFs sum to 1."""
+    bin_edges = np.linspace(-5, 30, 101)
+    distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
+
+    norm_1 = np.array(
+        [
+            quad(lambda x: distributions[0].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+    norm_2 = np.array(
+        [
+            quad(lambda x: distributions[1].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+    norm_3 = np.array(
+        [
+            quad(lambda x: distributions[2].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+
+    dataset = {
+        "bin_edges": bin_edges,
+        "means": np.array([5, 10, 15]),
+        "stds": np.array([1, 2, 3]),
+        "distributions": distributions,
+        "binned_pdfs": np.array([norm_1, norm_2, norm_3]),
+        "grid_points": np.array([1, 2, 3]),
+    }
+
+    return dataset
+
+
+def test_cdf_values(data):
+    from pyirf.interpolation import cdf_values
+
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+
+    # Assert empty histograms result in cdf containing zeros
+    assert np.all(cdf_values(np.zeros(shape=5)) == 0)
+
+    # Assert cdf is increasing or constant for actual pdfs
+    assert np.all(np.diff(cdf_est) >= 0)
+
+    # Assert cdf is capped at 1
+    assert np.max(cdf_est) == 1
+
+    # Assert estimated and true cdf are matching
+    assert np.allclose(cdf_est, data["distributions"][0].cdf(data["bin_edges"][1:]))
+
+
+def test_ppf_values(data):
+    from pyirf.interpolation import ppf_values, cdf_values
+
+    # Create quantiles, ignore the 0% and 100% quantile as they are analytically +- inf
+    quantiles = np.linspace(0, 1, 10)[1:-2]
+
+    # True ppf-values
+    ppf_true = data["distributions"][0].ppf(quantiles)
+
+    # Estimated ppf-values
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+    ppf_est = ppf_values(cdf_est, data["bin_edges"], quantiles)
+
+    # Assert truth and estimation match allowing for +- bin_width deviation
+    assert np.allclose(ppf_true, ppf_est, atol=np.diff(data["bin_edges"])[0])
+
+
+def test_pdf_from_ppf(data):
+    from pyirf.interpolation import ppf_values, cdf_values, pdf_from_ppf
+
+    # Create quantiles
+    quantiles = np.linspace(0, 1, 1000)
+
+    # Estimate ppf-values
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+    ppf_est = ppf_values(cdf_est, data["bin_edges"], quantiles)
+
+    # Compute pdf_values
+    pdf_est = pdf_from_ppf(quantiles, ppf_est, data["bin_edges"])
+
+    # Assert pdf-values matching true pdf within +-1%
+    assert np.allclose(pdf_est, data["binned_pdfs"][0], atol=1e-2)
+
+
+def test_norm_pdf(data):
+    from pyirf.interpolation import norm_pdf
+
+    assert np.allclose(norm_pdf(2 * data["binned_pdfs"][0]), data["binned_pdfs"][0])
+    assert np.allclose(norm_pdf(np.zeros(5)), 0)
+
+
+def test_interpolate_binned_pdf(data):
+    from pyirf.interpolation import interpolate_binned_pdf
+    from pyirf.binning import bin_center
+
+    interp = interpolate_binned_pdf(
+        edges=data["bin_edges"],
+        binned_pdf=data["binned_pdfs"][[0, 2], :],
+        m=data["grid_points"][[0, 2]],
+        mprime=data["grid_points"][1],
+        axis=-1,
+        quantile_resolution=1e-3,
+    )
+
+    bin_mids = bin_center(data["bin_edges"])
+    bin_width = np.diff(data["bin_edges"])[0]
+
+    # Estimate mean and standart_deviation from interpolant
+    interp_mean = np.average(bin_mids, weights=interp)
+    interp_std = np.sqrt(np.average((bin_mids - interp_mean) ** 2, weights=interp))
+
+    print(interp_mean)
+
+    # Assert they match the truth within one bin of uncertainty
+    assert np.isclose(interp_mean, data["means"][1], atol=bin_width)
+    assert np.isclose(interp_std, data["stds"][1], atol=bin_width)
+
 
 def test_interpolate_effective_area_per_energy_and_fov():
     """Test of interpolating of effective area using dummy model files."""
@@ -9,11 +135,11 @@ def test_interpolate_effective_area_per_energy_and_fov():
     n_th = 1
     en = np.logspace(-2, 2, n_en)
     # applying a simple sigmoid function
-    aeff0 = 1.e4 / (1 + 1 / en**2) * u.Unit('m2')
+    aeff0 = 1.0e4 / (1 + 1 / en ** 2) * u.Unit("m2")
 
     # assume that for parameters 'x' and 'y' the Aeff scales x*y*Aeff0
     x = [0.9, 1.1]
-    y = [8., 11.5]
+    y = [8.0, 11.5]
     n_grid = len(x) * len(y)
     aeff = np.empty((n_grid, n_th, n_en))
     pars = np.empty((n_grid, 2))
@@ -23,140 +149,11 @@ def test_interpolate_effective_area_per_energy_and_fov():
             aeff[i_grid, 0, :] = aeff0 * xx * yy / 10
             pars[i_grid, :] = np.array([xx, yy])
             i_grid += 1
-    aeff *= u.Unit('m2')
+    aeff *= u.Unit("m2")
     pars0 = (1, 10)
-    min_aeff = 1 * u.Unit('m2')
-    aeff_interp = interp.interpolate_effective_area_per_energy_and_fov(aeff, pars, pars0, min_effective_area=min_aeff, method='linear')
+    min_aeff = 1 * u.Unit("m2")
+    aeff_interp = interp.interpolate_effective_area_per_energy_and_fov(
+        aeff, pars, pars0, min_effective_area=min_aeff, method="linear"
+    )
     # allowing for 3% accuracy except of close to the minimum value of Aeff
     assert np.allclose(aeff_interp[:, 0], aeff0, rtol=0.03, atol=min_aeff)
-
-
-def calc_mean_std(matrix, vals):
-    """Auxiliary function to compute mean and std from 'matrix' along an axis which values are in 'values'."""
-    n_en = matrix.shape[0]
-    means = np.empty(n_en)
-    stds = np.empty(n_en)
-    for i_en in np.arange(n_en):
-        w = matrix[i_en, :]
-        if np.sum(w) > 0:
-            means[i_en] = np.average(vals, weights=w)
-            stds[i_en] = np.sqrt(np.cov(vals, aweights=w))
-        else:  # we need to skip the empty columns
-            means[i_en] = -1
-            stds[i_en] = -1
-    return means, stds
-
-
-def test_interpolate_energy_dispersion():
-    """Test of interpolation of energy dispersion matrix using a simple dummy model."""
-    x = [0.9, 1.1]
-    y = [8., 11.5]
-    n_grid = len(x) * len(y)
-    n_offset = 1
-    n_en = 30
-    n_mig = 20
-    clip_level = 1.e-3
-
-    # define simple dummy bias and resolution model using two parameters x and y
-    def get_bias_std(i_en, x, y):
-        i_en = i_en + 3 * ((x - 1) + (y - 10.))
-        de = n_en - i_en
-        de[de < 0] = 0.
-        bias = de**0.5 + n_mig / 2
-        rms = 5 - 2 * (i_en / n_en)
-        bias[i_en < 3] = 2 * n_mig  # return high values to zero out part of the table
-        rms[i_en < 3] = 0
-        return bias, rms
-
-    en = np.arange(n_en)[:, np.newaxis]
-    mig = np.arange(n_mig)[np.newaxis, :]
-
-    # generate true values
-    interp_pars = (1, 10)
-    bias, sigma = get_bias_std(en, *interp_pars)
-    mig_true = np.exp(-(mig - bias)**2 / (2 * sigma**2))
-    mig_true[mig_true < clip_level] = 0
-
-    # generate a grid of migration matrixes
-    i_grid = 0
-    pars_all = np.empty((n_grid, 2))
-    mig_all = np.empty((n_grid, n_en, n_mig, n_offset))
-    for xx in x:
-        for yy in y:
-            bias, sigma = get_bias_std(en, xx, yy)
-            mig_all[i_grid, :, :, 0] = (np.exp(-(mig - bias)**2 / (2 * sigma**2)))
-            pars_all[i_grid, :] = (xx, yy)
-            i_grid += 1
-    # do the interpolation and compare the results with expected ones
-    mig_interp = interp.interpolate_energy_dispersion(mig_all, pars_all, interp_pars, method='linear')
-
-    # check if all the energy bins have normalization 1 or 0 (can happen because of empty bins)
-    sums = np.sum(mig_interp[:, :, 0], axis=1)
-    assert np.logical_or(np.isclose(sums, 0., atol=1.e-5), np.isclose(sums, 1., atol=1.e-5)).min()
-
-    # now check if we reconstruct the mean and sigma roughly fine after interpolation
-    bias0, stds0 = calc_mean_std(mig_true, mig[0, :])  # true
-    bias, stds = calc_mean_std(mig_interp[:, :, 0], mig[0, :])  # interpolated
-
-    # first remove the bins that are empty in true value
-    idxs = bias0 > 0
-    bias0 = bias0[idxs]
-    bias = bias[idxs]
-    stds0 = stds0[idxs]
-    stds = stds[idxs]
-    # allowing for a 0.6 bin size error on the interpolated values
-    assert np.allclose(bias, bias0, atol=0.6, rtol=0.)
-    assert np.allclose(stds, stds0, atol=0.6, rtol=0.)
-
-@pytest.mark.parametrize("cumulative", [False, True])
-def test_interpolate_psf_table(cumulative):
-    """Test of interpolation of PSF tables using a simple dummy model"""
-    from pyirf.utils import cone_solid_angle
-    x = [0.9, 1.1]
-    y = [8., 11.5]
-    n_grid = len(x) * len(y)
-    n_offset = 1
-    n_en = 30
-    n_src_off = 20
-
-    # define simple dummy model for angular resolution using two parameters x and y
-    def get_sigma(i_en, x, y):
-        i_en = i_en + 3 * ((x - 1) + (y - 10.))
-        return np.exp(-(i_en - 30) / 20)
-
-    en = np.arange(n_en)[:, np.newaxis, np.newaxis]
-    src_bins = np.arange(n_src_off + 1) * u.deg
-    omegas = np.diff(cone_solid_angle(src_bins))
-    src_off = np.arange(n_src_off)[np.newaxis, np.newaxis, :]
-
-    # generate true values
-    interp_pars = (1, 10)
-    sigma = get_sigma(en, *interp_pars)
-    psf_true = np.exp(-src_off**2 / (2 * sigma**2)) * u.Unit('sr-1')
-
-    # generate a grid of PSF tables
-    i_grid = 0
-    pars_all = np.empty((n_grid, 2))
-    psfs_all = np.empty((n_grid, n_en, n_offset, n_src_off))
-    for xx in x:
-        for yy in y:
-            sigma = get_sigma(en, xx, yy)
-            psfs_all[i_grid] = np.exp(-src_off**2 / (2 * sigma**2))
-            pars_all[i_grid, :] = (xx, yy)
-            i_grid += 1
-    psfs_all *= u.Unit('sr-1')
-
-    # do the interpolation and compare the results with expected ones
-    psf_interp = interp.interpolate_psf_table(psfs_all, pars_all, interp_pars, src_bins, cumulative=cumulative, method='linear')
-
-    # check if all the energy bins have normalization 1 or 0 (can happen because of empty bins)
-    sums = np.sum(psf_interp * omegas, axis=2)
-    assert np.logical_or(np.isclose(sums, 0., atol=1.e-5), np.isclose(sums, 1., atol=1.e-5)).min()
-
-    # check the first two moments of the distribution for every energy
-    mean_true, std_true = calc_mean_std(psf_true[:, 0, :], src_off[0, 0, :])
-    mean_interp, std_interp = calc_mean_std(psf_interp[:, 0, :], src_off[0, 0, :])
-
-    # check if they are within 10% + 0.25 of bin size
-    assert np.allclose(mean_interp, mean_true, atol=0.25, rtol=0.1)
-    assert np.allclose(std_interp, std_true, atol=0.25, rtol=0.1)

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -13,16 +13,14 @@ def data():
     distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
 
     # create binned pdfs by interpolation of bin content
-    norm_1 = distributions[0].cdf(bin_edges[1:]) - distributions[0].cdf(bin_edges[:-1])
-    norm_2 = distributions[1].cdf(bin_edges[1:]) - distributions[1].cdf(bin_edges[:-1])
-    norm_3 = distributions[2].cdf(bin_edges[1:]) - distributions[2].cdf(bin_edges[:-1])
+    binned_pdfs = np.array([np.diff(dist.cdf(bin_edges)) for dist in distributions])
 
     dataset = {
         "bin_edges": bin_edges,
         "means": np.array([5, 10, 15]),
         "stds": np.array([1, 2, 3]),
         "distributions": distributions,
-        "binned_pdfs": np.array([norm_1, norm_2, norm_3]),
+        "binned_pdfs": binned_pdfs,
         "grid_points": np.array([1, 2, 3]),
     }
 
@@ -107,8 +105,6 @@ def test_interpolate_binned_pdf(data):
     # Estimate mean and standart_deviation from interpolant
     interp_mean = np.average(bin_mids, weights=interp)
     interp_std = np.sqrt(np.average((bin_mids - interp_mean) ** 2, weights=interp))
-
-    print(interp_mean)
 
     # Assert they match the truth within one bin of uncertainty
     assert np.isclose(interp_mean, data["means"][1], atol=bin_width)

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -3,7 +3,6 @@ import numpy as np
 import astropy.units as u
 import pytest
 from scipy.stats import norm
-from scipy.integrate import quad
 
 
 @pytest.fixture

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -91,9 +91,9 @@ def test_interpolate_binned_pdf(data):
 
     interp = interpolate_binned_pdf(
         edges=data["bin_edges"],
-        binned_pdf=data["binned_pdfs"][[0, 2], :],
-        m=data["grid_points"][[0, 2]],
-        mprime=data["grid_points"][1],
+        binned_pdfs=data["binned_pdfs"][[0, 2], :],
+        grid_points=data["grid_points"][[0, 2]],
+        target_point=data["grid_points"][1],
         axis=-1,
         quantile_resolution=1e-3,
     )

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -12,24 +12,10 @@ def data():
     bin_edges = np.linspace(-5, 30, 101)
     distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
 
-    norm_1 = np.array(
-        [
-            quad(lambda x: distributions[0].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
-    norm_2 = np.array(
-        [
-            quad(lambda x: distributions[1].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
-    norm_3 = np.array(
-        [
-            quad(lambda x: distributions[2].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
+    # create binned pdfs by interpolation of bin content
+    norm_1 = distributions[0].cdf(bin_edges[1:]) - distributions[0].cdf(bin_edges[:-1])
+    norm_2 = distributions[1].cdf(bin_edges[1:]) - distributions[1].cdf(bin_edges[:-1])
+    norm_3 = distributions[2].cdf(bin_edges[1:]) - distributions[2].cdf(bin_edges[:-1])
 
     dataset = {
         "bin_edges": bin_edges,


### PR DESCRIPTION
This is an alternative interpretation to the approach taken in #163. Instead of following the steps of [this tech report](https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf) closely, @maxnoe suggested to implement different solutions to the steps summarized in the tech reports Fig. 5.

On the upside, this method should scale easily to nD interpolation variables without using Delaunay simplices. This comes, however, at the price of worse results, at least in the testing case in my comment in #161.