### PR TITLE
Ignore under/overflow events in table operations

### DIFF
--- a/pyirf/benchmarks/angular_resolution.py
+++ b/pyirf/benchmarks/angular_resolution.py
@@ -37,9 +37,11 @@ def angular_resolution(
     # create a table to make use of groupby operations
     table = Table(events[[f"{energy_type}_energy", "theta"]])
 
-    table["bin_index"] = calculate_bin_indices(
+    table["bin_index"], valid = calculate_bin_indices(
         table[f"{energy_type}_energy"].quantity, energy_bins
     )
+    # ignore under / overflow
+    table = table[valid]
 
     n_bins =  len(energy_bins) - 1
     mask = (table["bin_index"] >= 0) & (table["bin_index"] < n_bins)

--- a/pyirf/benchmarks/energy_bias_resolution.py
+++ b/pyirf/benchmarks/energy_bias_resolution.py
@@ -85,9 +85,12 @@ def energy_bias_resolution(
     table = Table(events[["true_energy", "reco_energy"]])
     table["rel_error"] = (events["reco_energy"] / events["true_energy"]) - 1
 
-    table["bin_index"] = calculate_bin_indices(
+    table["bin_index"], valid = calculate_bin_indices(
         table[f"{energy_type}_energy"].quantity, energy_bins
     )
+    # ignore under/overflow events
+    table = table[valid]
+
     n_bins = len(energy_bins) - 1
     mask = (table["bin_index"] >= 0) & (table["bin_index"] < n_bins)
 

--- a/pyirf/binning.py
+++ b/pyirf/binning.py
@@ -142,12 +142,15 @@ def calculate_bin_indices(data, bins):
 
     if hasattr(data, "unit"):
         if not hasattr(bins, "unit"):
-            raise TypeError(f"If ``data`` is a Quantity, so must ``bin``, got {bins}")
+            raise TypeError(f"If ``data`` is a Quantity, so must ``bins``, got {bins}")
         unit = data.unit
         data = data.to_value(unit)
         bins = bins.to_value(unit)
 
-    return np.digitize(data, bins) - 1
+    idx = np.digitize(data, bins) - 1
+    n_bins = len(bins) - 1
+    valid = (idx >= 0) & (idx < n_bins)
+    return idx, valid
 
 
 def create_histogram_table(events, bins, key="reco_energy"):

--- a/pyirf/tests/test_binning.py
+++ b/pyirf/tests/test_binning.py
@@ -109,13 +109,18 @@ def test_calculate_bin_indices():
     values = [0.5, 0.5, 1, 1.1, 1.9, 2, -1, 2.5]
 
     true_idx = np.array([0, 0, 1, 1, 1, 2, -1, 2])
+    true_valid = np.array([True, True, True, True, True, False, False, False])
 
-    assert np.all(calculate_bin_indices(values, bins) == true_idx)
+    idx, valid = calculate_bin_indices(values, bins)
+    assert np.all(idx == true_idx)
+    assert np.all(valid == true_valid)
 
     # test with units
     bins *= u.TeV
     values *= 1000 * u.GeV
-    assert np.all(calculate_bin_indices(values, bins) == true_idx)
+    idx, valid = calculate_bin_indices(values, bins)
+    assert np.all(idx == true_idx)
+    assert np.all(valid == true_valid)
 
 
 def test_resample_bins_1d():

--- a/pyirf/tests/test_cuts.py
+++ b/pyirf/tests/test_cuts.py
@@ -28,6 +28,10 @@ def test_calculate_percentile_cuts():
 
     values = np.append(dist1.rvs(size=N), dist2.rvs(size=N)) * u.deg
     bin_values = np.append(np.zeros(N), np.ones(N)) * u.m
+    # add some values outside of binning to test that under/overflow are ignored
+    bin_values[10] = 5 * u.m
+    bin_values[30] = -1 * u.m
+
     bins = [-0.5, 0.5, 1.5] * u.m
 
     cuts = calculate_percentile_cut(values, bin_values, bins, fill_value=np.nan * u.deg)


### PR DESCRIPTION
evaluate_binned_cut, angular_resolution and energy_bias_resolution were creating exceptions on events outside the specified bins.

Reported by @FrancaCassol 