### PR TITLE
Check Table in angular_separation functions

### DIFF
--- a/pyirf/exceptions.py
+++ b/pyirf/exceptions.py
@@ -18,7 +18,5 @@ class WrongColumnUnit(IRFException):
 
     def __init__(self, column, unit, expected):
         super().__init__(
-            f'Unit {unit} of column "{column}"'
-            f' has incompatible unit "{unit}", expected {expected}'
-            f" required column {column}"
+            f'Column "{column}" has incompatible unit "{unit}", expected "{expected}".'
         )

--- a/pyirf/tests/test_utils.py
+++ b/pyirf/tests/test_utils.py
@@ -35,6 +35,10 @@ def test_cone_solid_angle():
 def test_check_table():
     from pyirf.utils import check_table
 
+    # works with Table as well as QTable
+    check_table(Table({"foo": [1]}), required_columns=["foo"])
+    check_table(Table({"foo": [1] * u.m}), required_units={"foo": u.m})
+    check_table(QTable({"foo": [1] * u.m}), required_units={"foo": u.m})
 
     t = Table({"bar": [0, 1, 2] * u.TeV})
 
@@ -96,12 +100,14 @@ def test_calculate_source_fov_offset():
     from pyirf.utils import calculate_source_fov_offset
 
     a = u.Quantity([1.0], u.deg)
-    t = QTable({
-        'pointing_az': a,
-        'pointing_alt': a,
-        'true_az': a,
-        'true_alt': a,
-    })
+    t = QTable(
+        {
+            "pointing_az": a,
+            "pointing_alt": a,
+            "true_az": a,
+            "true_alt": a,
+        }
+    )
 
     assert u.isclose(calculate_source_fov_offset(t), 0.0 * u.deg)
 
@@ -110,12 +116,16 @@ def test_check_histograms():
     from pyirf.binning import create_histogram_table
     from pyirf.utils import check_histograms
 
-    events1 = QTable({
-        'reco_energy': [1, 1, 10, 100, 100, 100] * u.TeV,
-    })
-    events2 = QTable({
-        'reco_energy': [100, 100, 100] * u.TeV,
-    })
+    events1 = QTable(
+        {
+            "reco_energy": [1, 1, 10, 100, 100, 100] * u.TeV,
+        }
+    )
+    events2 = QTable(
+        {
+            "reco_energy": [100, 100, 100] * u.TeV,
+        }
+    )
     bins = [0.5, 5, 50, 500] * u.TeV
 
     hist1 = create_histogram_table(events1, bins)

--- a/pyirf/tests/test_utils.py
+++ b/pyirf/tests/test_utils.py
@@ -33,6 +33,7 @@ def test_cone_solid_angle():
 def test_check_table():
     from pyirf.exceptions import MissingColumns, WrongColumnUnit
     from pyirf.utils import check_table
+    from astropy.table import Table
 
     t = QTable({'bar': [0, 1, 2] * u.TeV})
 
@@ -49,3 +50,7 @@ def test_check_table():
 
     # m is convertible
     check_table(t, required_units={'bar': u.cm})
+
+    t = Table({'bar': [0, 1, 2]})
+    with pytest.raises(WrongColumnUnit):
+        check_table(t, required_units={'bar': u.cm})

--- a/pyirf/utils.py
+++ b/pyirf/utils.py
@@ -168,5 +168,5 @@ def check_table(table, required_columns=None, required_units=None):
                 raise MissingColumns(col)
 
             unit = table[col].unit
-            if not expected.is_equivalent(unit):
+            if not unit or not expected.is_equivalent(unit):
                 raise WrongColumnUnit(col, unit, expected)

--- a/pyirf/utils.py
+++ b/pyirf/utils.py
@@ -1,9 +1,9 @@
-import numpy as np
 import astropy.units as u
+import numpy as np
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.table import QTable
 
 from .exceptions import MissingColumns, WrongColumnUnit
-
 
 __all__ = [
     "is_scalar",

--- a/pyirf/utils.py
+++ b/pyirf/utils.py
@@ -50,6 +50,7 @@ def calculate_theta(events, assumed_source_az, assumed_source_alt):
         Angular separation between the assumed and reconstructed positions
         in the sky.
     """
+    check_table(events, required_units={"reco_az": u.deg, "reco_alt": u.deg})
     theta = angular_separation(
         assumed_source_az,
         assumed_source_alt,
@@ -78,6 +79,15 @@ def calculate_source_fov_offset(events, prefix="true"):
         Angular separation between the true and pointing positions
         in the sky.
     """
+    check_table(
+        events,
+        required_units={
+            f"{prefix}_az": u.deg,
+            f"{prefix}_alt": u.deg,
+            "pointing_az": u.deg,
+            "pointing_alt": u.deg,
+        },
+    )
     theta = angular_separation(
         events[f"{prefix}_az"],
         events[f"{prefix}_alt"],

--- a/pyirf/utils.py
+++ b/pyirf/utils.py
@@ -143,7 +143,7 @@ def check_table(table, required_columns=None, required_units=None):
 
     Parameters
     ----------
-    table: astropy.table.QTable
+    table: astropy.table.Table
         Table to check
     required_columns: iterable[str]
         Column names that are required to be present
@@ -157,6 +157,7 @@ def check_table(table, required_columns=None, required_units=None):
         as keys in ``required_units are`` not present in the table.
     WrongColumnUnit: if any column has the wrong unit
     """
+    table = QTable(table)
     if required_columns is not None:
         missing = set(required_columns) - set(table.colnames)
         if missing:


### PR DESCRIPTION
Hi there,

I spent too much time figuring out why my angular resolution was as bad as it was. I found out it was because of how [`astropy.coordinates.angular_separation`](https://docs.astropy.org/en/stable/_modules/astropy/coordinates/angle_utilities.html#angular_separation) behaves when given floats *and* quantities (i.e. one in deg, the other in rad).

`angular_separation` is what is used in our `pyirf.utils.calculate_theta`.

The problem was giving a `Table` instead of a `QTable`, where the columns are no quantities, thus the values get interpreted as floats and thus radians instead of degree (if they were in degree of course).

1) I added our `check_table` function to the functions that use `angular_separation`.
2) I checked for `.unit` being `None`, thus filtering out also the case where a `Table` ist passed (instead of a `QTable`). This fails with some "Column ... has incompatible unit None, expected ...". Here we could decide on checking `isinstance(events, QTable)`.
3) I fixed the very repetitive wording of the wrong unit exception

The thing with these changes is, that incorrect usage before just yields wrong results, where the error (on the user side) is not obvious, after these changes incorrect usage fails.