### PR TITLE
Improve under/overflow and nan handling in binning related functions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+template: |
+  ## What's Changed since $PREVIOUS_TAG
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,13 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
-          pip install -U pip setuptools wheel
-          pip install --use-feature=2020-resolver -e .[all]
+          pip install -U pip setuptools wheel restructuredtext_lint
+          pip install -e .[all]
           pip freeze
+
+      - name: Check README
+        run: |
+          rst-lint README.rst
 
       - name: Tests
         run: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-exclude pyirf/_dev_version.py
+prune pyirf/_dev_version
 include pyirf/resources/*

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,6 @@ pyirf |ci| |codacy| |coverage| |doilatest|
   :target: https://codecov.io/gh/cta-observatory/pyirf
 .. |doilatest| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4740755.svg
   :target: https://doi.org/10.5281/zenodo.4740755
-..|zenodo| 
 
 *pyirf* is a python library for the generation of Instrument Response
 Functions (IRFs) and sensitivities for the

--- a/README.rst
+++ b/README.rst
@@ -10,17 +10,14 @@ pyirf |ci| |codacy| |coverage| |doilatest|
   :target: https://codecov.io/gh/cta-observatory/pyirf
 .. |doilatest| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4740755.svg
   :target: https://doi.org/10.5281/zenodo.4740755
-.. |doi_v0.5.0| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4748994.svg
-  :target: https://doi.org/10.5281/zenodo.4748994
-.. |doi_v0.4.0| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4304466.svg
-  :target: https://doi.org/10.5281/zenodo.4304466
+..|zenodo| 
 
-*pyirf* is a python3-based library for the generation of Instrument Response
+*pyirf* is a python library for the generation of Instrument Response
 Functions (IRFs) and sensitivities for the
 `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_ .
 
 Thanks to its simple input/output and modular function-based structure,
-it can be potentially used to process also data from other Imaging Atmospheric
+it can be used to process also data from other Imaging Atmospheric
 Cherenkov Telescopes (IACTs).
 
 - **Source code:** https://github.com/cta-observatory/pyirf
@@ -32,5 +29,4 @@ If you use a released version of this software for a publication,
 please cite it by using the corresponding DOI:
 
 - latest : |doilatest|
-- v0.5.0 : |doi_v0.5.0|
-- v0.4.0 : |doi_v0.4.0|
+- all versions: `Please visit Zenodo <https://zenodo.org/record/5833284>`_ and select the correct version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,42 @@ We use a one-line description of every pull request.
 .. - [#XXX] TITLE (AUTHOR)
 
 
+.. _pyirf_0p7p0_release:
+
+`0.7.0 <https://github.com/cta-observatory/pyirf/releases/tag/v0.7.0>`__ (2022-04-14)
+-------------------------------------------------------------------------------------
+
+Summary
++++++++
+
+- Released April 4th, 2022
+- 2 Contributors
+
+Contributors
+++++++++++++
+
+- Rune Michael Dominik
+- Maximilian Nöthe
+
+Description
++++++++++++
+
+
+The main feature of this release is new methods for interpolation of
+pdf-like IRFs, i.e. energy dispersion and psf table.
+These methods replace the methods not suitable for interpolation of probability
+densities introduced in pyirf 0.5.0.
+
+This release also adds support for astropy 5.0.
+
+merged pull requests
+++++++++++++++++++++
+
+- `#174 <https://github.com/cta-observatory/pyirf/pull/174>`_ Adapted quantile interpolation
+- `#177 <https://github.com/cta-observatory/pyirf/pull/177>`_ Add interpolate_psf_table to ``__all__``
+- `#175 <https://github.com/cta-observatory/pyirf/pull/175>`_ Allow and test astropy=5
+
+
 .. _pyirf_0p6p0_release:
 
 `0.6.0 <https://github.com/cta-observatory/pyirf/releases/tag/v0.6.0>`__ (2021-01-10)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,53 @@ We use a one-line description of every pull request.
 ..
 .. - [#XXX] TITLE (AUTHOR)
 
+
+.. _pyirf_0p6p0_release:
+
+`0.6.0 <https://github.com/cta-observatory/pyirf/releases/tag/v0.6.0>`__ (2021-01-10)
+-------------------------------------------------------------------------------------
+
+Summary
++++++++
+
+- Released January 10th, 2022
+- 5 Contributors
+
+Contributors
+++++++++++++
+
+- Maximilian Nöthe
+- Michael Punch
+- Michele Peresano
+- Julian Sitarek
+- Gernot Maier
+
+Description
++++++++++++
+
+This release is mainly a maintenance release with few changes to the functionality.
+The main feature is the update to gammapy 0.19 in the tests and the utility functions
+to get gammapy IRF classes from pyirf output.
+
+In the future, we will more directly interface with and use gammapy, now that
+the science tool decision was taken.
+
+
+merged pull requests
+++++++++++++++++++++
+
+- `#164 <https://github.com/cta-observatory/pyirf/pull/164>`_ Update to gammapy 0.19
+- `#168 <https://github.com/cta-observatory/pyirf/pull/168>`_ Enable intersphinx, use to link to gammapy docs
+- `#171 <https://github.com/cta-observatory/pyirf/pull/171>`_ Add release-drafter action
+- `#172 <https://github.com/cta-observatory/pyirf/pull/172>`_ Replace outdated link to redmine by xwiki link
+- `#165 <https://github.com/cta-observatory/pyirf/pull/165>`_ Do not require private DL2 event display output anymore for unit tests
+- `#162 <https://github.com/cta-observatory/pyirf/pull/162>`_ Refactor hist normalization, remove assert from library code
+- `#160 <https://github.com/cta-observatory/pyirf/pull/160>`_ Add missing docs pages
+- `#156 <https://github.com/cta-observatory/pyirf/pull/156>`_ Interpolate psf
+- `#159 <https://github.com/cta-observatory/pyirf/pull/159>`_ GADF URL corrections
+- `#154 <https://github.com/cta-observatory/pyirf/pull/154>`_ Fill energy and/or angular resolution tables with NaNs if input events table is empty
+
+
 .. _pyirf_0p5p0_release:
 
 `0.5.0 <https://github.com/cta-observatory/pyirf/releases/tag/v0.5.0>`__ (2021-05-05)
@@ -69,7 +116,7 @@ proton and helium spectrum.
 The other pull requests are mainly maintenance and a small bugfix.
 
 
-Merged Pull Requests
+merged pull requests
 ++++++++++++++++++++
 
 - `#149 <https://github.com/cta-observatory/pyirf/pull/149>`_ Interpolation docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ html_theme_options = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.7", None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),
     "gammapy": ("https://docs.gammapy.org/0.18/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,14 @@ html_theme_options = {
     'display_version': True,
 }
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3.7", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "astropy": ("https://docs.astropy.org/en/latest/", None),
+    "gammapy": ("https://docs.gammapy.org/0.18/", None),
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/notebooks/fact_example.ipynb
+++ b/docs/notebooks/fact_example.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! curl -z gamma_test_dl3.hdf5 -LO https://factdata.app.tu-dortmund.de/dl3/FACT-Tools/v1.1.2/gamma_test_dl3.hdf5"
+    "! curl -z gamma_test_dl3.hdf5 -fLO https://factdata.app.tu-dortmund.de/dl3/FACT-Tools/v1.1.2/gamma_test_dl3.hdf5"
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - numpy
   - ipython
   - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - jupyter
   - matplotlib
   - scipy
-  - astropy>=4.0.2,<5
+  - astropy=5
   - setuptools
   - tqdm
   # tests

--- a/pyirf/_dev_version/__init__.py
+++ b/pyirf/_dev_version/__init__.py
@@ -4,6 +4,6 @@
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root="..", relative_to=__file__)
+    version = get_version(root="../..", relative_to=__file__)
 except Exception as e:
     raise ImportError(f"setuptools_scm broken or not installed: {e}")

--- a/pyirf/benchmarks/tests/test_angular_resolution.py
+++ b/pyirf/benchmarks/tests/test_angular_resolution.py
@@ -37,10 +37,14 @@ def test_angular_resolution():
         'theta': np.abs(np.random.normal(0, true_resolution)) * u.deg
     })
 
+    # add nans to test if nans are ignored
+    events["true_energy"].value[500] = np.nan
+    events["true_energy"].value[1500] = np.nan
+
     ang_res = angular_resolution(
         events,
         [1, 10, 100] * u.TeV,
-    )['angular_resolution'].quantity
+    )['angular_resolution']
 
     assert len(ang_res) == 2
     assert u.isclose(ang_res[0], TRUE_RES_1 * u.deg, rtol=0.05)

--- a/pyirf/gammapy.py
+++ b/pyirf/gammapy.py
@@ -25,7 +25,7 @@ def create_effective_area_table_2d(
     fov_offset_bins,
 ):
     '''
-    Create a ``gammapy.irf.EffectiveAreaTable2D`` from pyirf outputs.
+    Create a :py:class:`gammapy.irf.EffectiveAreaTable2D` from pyirf outputs.
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def create_effective_area_table_2d(
     Returns
     -------
     gammapy.irf.EffectiveAreaTable2D
-    
+    aeff2d: gammapy.irf.EffectiveAreaTable2D
     '''
     offset_axis = _create_offset_axis(fov_offset_bins)
     energy_axis_true = _create_energy_axis_true(true_energy_bins)
@@ -66,8 +66,8 @@ def create_psf_3d(
     fov_offset_bins,
 ):
     """
-    Create a ``gammapy.irf.PSF3D`` from pyirf outputs.
-    
+    Create a :py:class:`gammapy.irf.PSF3D` from pyirf outputs.
+
     Parameters
     ----------
     psf: astropy.units.Quantity[(solid angle)^-1]
@@ -83,8 +83,7 @@ def create_psf_3d(
 
     Returns
     -------
-    gammapy.irf.PSF3D
-    
+    psf: gammapy.irf.PSF3D
     """
     offset_axis = _create_offset_axis(fov_offset_bins)
     energy_axis_true = _create_energy_axis_true(true_energy_bins)
@@ -108,8 +107,8 @@ def create_energy_dispersion_2d(
     fov_offset_bins,
 ):
     """
-    Create a ``gammapy.irf.EnergyDispersion2D`` from pyirf outputs.
-    
+    Create a :py:class:`gammapy.irf.EnergyDispersion2D` from pyirf outputs.
+
     Parameters
     ----------
     energy_dispersion: numpy.ndarray
@@ -125,8 +124,7 @@ def create_energy_dispersion_2d(
 
     Returns
     -------
-    gammapy.irf.EnergyDispersion2D
-    
+    edisp: gammapy.irf.EnergyDispersion2D
     """
     offset_axis = _create_offset_axis(fov_offset_bins)
     energy_axis_true = _create_energy_axis_true(true_energy_bins)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -145,10 +145,10 @@ def norm_pdf(pdf_values):
     """
     norm = np.sum(pdf_values, axis=-1)
 
-    # Ignore errors from rows without errors as they are set to 0 through nan_to_num
-    with np.errstate(invalid="ignore"):
-        normed_pdf_values = pdf_values / norm[..., np.newaxis]
-    return np.nan_to_num(normed_pdf_values)
+    # Norm all binned_pdfs to unity that are not empty
+    normed_pdf_values = np.divide(pdf_values, norm[..., np.newaxis], out=np.zeros_like(pdf_values), where=norm[..., np.newaxis] != 0)
+
+    return normed_pdf_values
 
 
 def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resolution):
@@ -218,7 +218,7 @@ def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resoluti
     normed_interpolated_pdfs = norm_pdf(interpolated_pdfs)
 
     # Re-swap axes and set all nans to zero
-    return np.swapaxes(normed_interpolated_pdfs, axis, -1)
+    return np.swapaxes(np.nan_to_num(normed_interpolated_pdfs), axis, -1)
 
 
 @u.quantity_input(effective_area=u.m ** 2)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -9,6 +9,7 @@ from pyirf.binning import bin_center
 __all__ = [
     "interpolate_effective_area_per_energy_and_fov",
     "interpolate_energy_dispersion",
+    "interpolate_psf_table",
 ]
 
 

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -55,8 +55,8 @@ def ppf_values(cdfs, edges, quantiles):
         """
 
         # Find last 0 and first 1 entry
-        last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
-        first_1 = np.min(np.arange(len(cdf))[cdf == 1])
+        last_0 = np.nonzero(cdf == 0)[0][-1] if cdf[0] == 0 else 0
+        first_1 = np.nonzero(cdf == 1.0)[0][0]
 
         # Predefine selection mask
         selection = np.ones(len(cdf), dtype=bool)

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -2,22 +2,23 @@
 
 import numpy as np
 import astropy.units as u
-from scipy.interpolate import griddata
+from scipy.interpolate import interp1d, griddata
 from pyirf.utils import cone_solid_angle
+from pyirf.binning import bin_center
 
 __all__ = [
-    'interpolate_effective_area_per_energy_and_fov',
-    'interpolate_energy_dispersion',
+    "interpolate_effective_area_per_energy_and_fov",
+    "interpolate_energy_dispersion",
 ]
 
 
-@u.quantity_input(effective_area=u.m**2)
+@u.quantity_input(effective_area=u.m ** 2)
 def interpolate_effective_area_per_energy_and_fov(
     effective_area,
     grid_points,
     target_point,
-    min_effective_area=1. * u.Unit('m2'),
-    method='linear',
+    min_effective_area=1.0 * u.Unit("m2"),
+    method="linear",
 ):
     """
     Takes a grid of effective areas for a bunch of different parameters
@@ -43,8 +44,8 @@ def interpolate_effective_area_per_energy_and_fov(
     """
 
     # get rid of units
-    effective_area = effective_area.to_value(u.m**2)
-    min_effective_area = min_effective_area.to_value(u.m**2)
+    effective_area = effective_area.to_value(u.m ** 2)
+    min_effective_area = min_effective_area.to_value(u.m ** 2)
 
     # remove zeros and log it
     effective_area[effective_area < min_effective_area] = min_effective_area
@@ -54,45 +55,130 @@ def interpolate_effective_area_per_energy_and_fov(
     aeff_interp = griddata(grid_points, effective_area, target_point, method=method).T
     # exp it and set to zero too low values
     aeff_interp = np.exp(aeff_interp)
-    aeff_interp[aeff_interp < min_effective_area * 1.1] = 0  # 1.1 to correct for numerical uncertainty and interpolation
-    return u.Quantity(aeff_interp, u.m**2, copy=False)
+    aeff_interp[
+        aeff_interp < min_effective_area * 1.1
+    ] = 0  # 1.1 to correct for numerical uncertainty and interpolation
+    return u.Quantity(aeff_interp, u.m ** 2, copy=False)
 
 
 def interpolate_energy_dispersion(
-    energy_dispersions,
-    grid_points,
-    target_point,
-    method='linear',
+    edges, hists, m, mprime, axis, quantile_resolution=1e-3
 ):
     """
     Takes a grid of dispersion matrixes for a bunch of different parameters
-    and interpolates it to given value of those parameters
+    and interpolates it to given value of those parameters.
+    This function provides an adapted version of the quantile Interpolation introduced
+    in [1].
+    Instead of following this method closely, it implements different approaches to the
+    steps shown in Fig. 5 of [1].
 
     Parameters
     ----------
-    energy_dispersions: np.ndarray
-        grid of energy migrations, of shape (n_grid_points, n_energy_bins, n_migration_bins, n_fov_offset_bins)
-    grid_points: np.ndarray
-        array of parameters corresponding to energy_dispersions, of shape (n_grid_points, n_interp_dim)
-    target_point: np.ndarray
-        values of parameters for which the interpolation is performed, of shape (n_interp_dim)
-    method: 'linear’, ‘nearest’, ‘cubic’
-        Interpolation method
+    edges: numpy.ndarray, shape=(M+1)
+        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
+
+    hists: numpy.ndarray, shape=(N,...,M,...)
+        Array of M bin-heights (along the ordinate ("y") axis) for each of the 2 input templates.
+        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
+        be given at the dimension specified by axis.
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's qunatiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    axis: int
+        Axis along which the pdfs used for interpolation are located
+
+    quantile_resolution: float
+        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
 
     Returns
     -------
-    matrix_interp: np.ndarray
-        Interpolated dispersion matrix 3D array with shape (n_energy_bins, n_migration_bins, n_fov_offset_bins)
+    f_new: numpy.ndarray, shape=(1,...,M,...)
+        Interpolated histograms
+
+    References
+    ----------
+    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
+           for Ensemble Visualization
+           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
     """
+    if hists.ndim > 2:
+        # To have the needed axis always at the last index, as the number of indices is
+        # not safely propageted through the interpolation but the last element remains the last element
+        hists = np.swapaxes(hists, axis, -1)
 
-    # interpolation
-    matrix_interp = griddata(grid_points, energy_dispersions, target_point, method=method)
+    # Compute CDFs
+    cdfs = np.cumsum(hists, axis=-1)
 
-    # now we need to renormalize along the migration axis
-    norm = np.sum(matrix_interp, axis=1, keepdims=True)
-    # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
-    mig_norm = np.divide(matrix_interp, norm, out=np.zeros_like(matrix_interp), where=norm != 0)
-    return mig_norm
+    cdfs = cdfs / np.expand_dims(np.max(cdfs, axis=-1), axis=-1)
+
+    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
+
+    bin_mids = bin_center(edges)
+
+    # create ppf values from cdf samples via interpolation of the cdfs, determine quantile steps of [1]
+    ppfs_resampled = np.apply_along_axis(
+        lambda cdf: interp1d(
+            cdf, bin_mids, bounds_error=False, fill_value="extrapolate"
+        )(quantiles),
+        -1,
+        cdfs,
+    )
+
+    # nD interpolation of ppf values, interpolate quantiles step of [1]
+    ppf_interpolant = griddata(m, ppfs_resampled, mprime)
+
+    # recalculate pdf values, evaluate interpolant PDF values step of [1]
+    pdf_interpolant = np.diff(quantiles) / np.diff(ppf_interpolant, axis=-1)
+
+    if hists.ndim > 2:
+        # Unconventional solution to make this usable with np.apply_along_axis for readability
+        # The ppf bin-mids are computed since the pdf-values are derived through derivation
+        # from the ppf-values
+        xyconcat = np.concatenate(
+            (
+                ppf_interpolant[..., :-1] + np.diff(ppf_interpolant) / 2,
+                np.nan_to_num(pdf_interpolant),
+            ),
+            axis=-1,
+        )
+
+        # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
+        # correct bin height via the midpoint rule formulation of the trapezoidal rule
+        result = np.apply_along_axis(
+            lambda xy: np.diff(edges)
+            * np.nan_to_num(
+                interp1d(
+                    xy[: int(len(xy) / 2)],
+                    xy[int(len(xy) / 2) :],
+                    bounds_error=False,
+                    fill_value=(0, 0),
+                )(bin_mids)
+            ),
+            -1,
+            xyconcat,
+        )
+
+        # Renormalize histogram to a sum of 1
+        norm = np.sum(result, axis=-1)
+        norm = np.repeat(np.expand_dims(norm, -1), result.shape[-1], axis=-1)
+        norm[norm == 0] = np.nan
+
+        return np.swapaxes(np.nan_to_num(result / norm), axis, -1)
+    else:
+        # Same as above, only simpler as only one axis exists
+        result = interp1d(
+            bin_center(ppf_interpolant.squeeze()),
+            np.nan_to_num(pdf_interpolant.squeeze()),
+            bounds_error=False,
+            fill_value=0,
+        )(bin_mids)
+        result = np.diff(edges) * result
+        return np.nan_to_num(result / np.sum(result))
 
 
 def interpolate_psf_table(
@@ -101,7 +187,7 @@ def interpolate_psf_table(
     target_point,
     source_offset_bins,
     cumulative=False,
-    method='linear',
+    method="linear",
 ):
     """
     Takes a grid of PSF tables for a bunch of different parameters
@@ -132,14 +218,20 @@ def interpolate_psf_table(
     if cumulative:
         psfs = np.cumsum(psfs, axis=3)
 
-    psf_interp = griddata(grid_points, psfs.to_value('sr-1'), target_point, method=method) * u.Unit('sr-1')
+    psf_interp = griddata(
+        grid_points, psfs.to_value("sr-1"), target_point, method=method
+    ) * u.Unit("sr-1")
 
     if cumulative:
-        psf_interp = np.concatenate((psf_interp[...,:1], np.diff(psf_interp, axis=2)), axis=2)
+        psf_interp = np.concatenate(
+            (psf_interp[..., :1], np.diff(psf_interp, axis=2)), axis=2
+        )
 
     # now we need to renormalize along the source offset axis
     omegas = np.diff(cone_solid_angle(source_offset_bins))
     norm = np.sum(psf_interp * omegas, axis=2, keepdims=True)
     # By using out and where, it is ensured that columns with norm = 0 will have 0 values without raising an invalid value warning
-    psf_norm = np.divide(psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0)
+    psf_norm = np.divide(
+        psf_interp, norm, out=np.zeros_like(psf_interp), where=norm != 0
+    )
     return psf_norm

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -54,8 +54,6 @@ def ppf_values(cdfs, edges, quantiles):
         the interpolation polynom.
         """
 
-        # cdf = np.append(np.array(0), cdf)
-
         # Find last 0 and first 1 entry
         last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
         first_1 = np.min(np.arange(len(cdf))[cdf == 1])

--- a/pyirf/interpolation.py
+++ b/pyirf/interpolation.py
@@ -12,6 +12,221 @@ __all__ = [
 ]
 
 
+def cdf_values(binned_pdf):
+    """
+    Compute cdf values and assure they are normed to unity
+    """
+    cdfs = np.cumsum(binned_pdf, axis=-1)
+
+    # assure the last cdf value is 1, ignore errors for empty pdfs as they are reset to 0 by nan_to_num
+    with np.errstate(invalid="ignore"):
+        cdfs = np.nan_to_num(cdfs / np.max(cdfs, axis=-1)[..., np.newaxis])
+
+    return cdfs
+
+
+def ppf_values(cdfs, bin_mids, m, mprime, quantiles):
+    """
+    Compute ppfs from cdfs and interpolate them to the desired interpolation point
+
+    Parameters
+    ----------
+    cdfs: numpy.ndarray, shape=(N,...,M)
+        Corresponding cdf-values for all quantiles
+
+    bin_mids: numpy.ndarray, shape=(M)
+        M bin-midss for which the cdf-values are known
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's quantiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    quantiles: numpy.ndarray, shape=(L)
+        L quantiles for which the ppf_values are known
+
+    Returns
+    -------
+    ppfs: numpy.ndarray, shape=(1,...,L)
+        Corresponding ppf-values for all quantiles at the target interpolation point
+    """
+
+    def cropped_interp(cdf):
+        """
+        create ppf-values through inverse interpolation of the cdf, avoiding repeating 0 and 1 entries
+        around the first and last bins as well as repeating values due to zero bins
+        in between filled bins. Both cases would result in division by zero errors when computing
+        the interpolation polynom.
+        """
+        # Find last 0 and first 1 entry
+        last_0 = np.max(np.arange(len(cdf))[cdf == 0]) if cdf[0] == 0 else 0
+        first_1 = np.min(np.arange(len(cdf))[cdf == 1])
+
+        # Predefine selection mask
+        selection = np.ones(len(cdf), dtype=bool)
+
+        # Keep only the first of subsequently matching values
+        selection[1:] = cdf[1:] != cdf[:-1]
+
+        # Keep only the last 0 and first 1 entry
+        selection[:last_0] = False
+        selection[last_0] = True
+        selection[first_1 + 1 :] = False
+        selection[first_1] = True
+
+        # create ppf values from selected bins
+        return interp1d(
+            cdf[selection],
+            bin_mids[selection],
+            bounds_error=False,
+            fill_value="extrapolate",
+        )(quantiles)
+
+    # create ppf values from cdf samples via interpolation of the cdfs
+    # return nan for empty pdfs
+    ppfs = np.apply_along_axis(
+        lambda cdf: cropped_interp(cdf)
+        if np.sum(cdf) > 0
+        else np.full_like(quantiles, np.nan),
+        -1,
+        cdfs,
+    )
+    # nD interpolation of ppf values
+    return griddata(m, ppfs, mprime)
+
+
+def reconstruct_pdf_values(quantiles, ppfs, edges):
+    """
+    Reconstruct pdf from ppf and evaluate at desired points.
+
+    Parameters
+    ----------
+    quantiles: numpy.ndarray, shape=(L)
+        L quantiles for which the ppf_values are known
+
+    ppfs: numpy.ndarray, shape=(1,...,L)
+        Corresponding ppf-values for all quantiles
+
+    edges: numpy.ndarray, shape=(M+1)
+        Binning of the desired binned pdf
+
+    Returns
+    -------
+    pdf_values: numpy.ndarray, shape=(1,...,M)
+        Recomputed, binned pdf
+    """
+    # recalculate pdf values through numerical differentiation
+    pdf_interpolant = np.nan_to_num(np.diff(quantiles) / np.diff(ppfs, axis=-1))
+
+    # Unconventional solution to make this usable with np.apply_along_axis for readability
+    # The ppf bin-mids are computed since the pdf-values are derived through derivation
+    # from the ppf-values
+    xyconcat = np.concatenate(
+        (ppfs[..., :-1] + np.diff(ppfs) / 2, pdf_interpolant), axis=-1
+    )
+
+    # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
+    # correct bin height via the midpoint rule formulation of the trapezoidal rule
+    pdf_values = np.apply_along_axis(
+        lambda xy: np.diff(edges)
+        * np.nan_to_num(
+            interp1d(
+                xy[: int(len(xy) / 2)],
+                xy[int(len(xy) / 2) :],
+                bounds_error=False,
+                fill_value=(0, 0),
+            )(edges[:-1])
+        ),
+        -1,
+        xyconcat,
+    )
+
+    return pdf_values
+
+
+def norm_pdf(pdf_values):
+    """
+    Normalize binned_pdf to a sum of 1
+    """
+    norm = np.sum(pdf_values, axis=-1)
+
+    # Ignore errors from rows without errors as they are set to 0 through nan_to_num
+    with np.errstate(invalid="ignore"):
+        normed_pdf_values = pdf_values / norm[..., np.newaxis]
+    return np.nan_to_num(normed_pdf_values)
+
+
+def interpolate_binned_pdf(edges, binned_pdf, m, mprime, axis, quantile_resolution):
+    """
+    Takes a grid of binned pdfs for a bunch of different parameters
+    and interpolates it to given value of those parameters.
+    This function provides an adapted version of the quantile interpolation introduced
+    in [1].
+    Instead of following this method closely, it implements different approaches to the
+    steps shown in Fig. 5 of [1].
+
+    Parameters
+    ----------
+    edges: numpy.ndarray, shape=(M+1)
+        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
+
+    binned_pdf: numpy.ndarray, shape=(N,...,M,...)
+        Array of M bin-heights (along the ordinate ("y") axis) for each of the N input templates.
+        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
+        be given at the dimension specified by axis.
+
+    m: numpy.ndarray, shape=(N, O)
+        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's quantiles
+        are expected to vary linearly between these two reference points.
+
+    m_prime: numpy.ndarray, shape=(O)
+        Value for which the interpolation is performed (target point)
+
+    axis: int
+        Axis along which the pdfs used for interpolation are located
+
+    quantile_resolution: float
+        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
+
+    Returns
+    -------
+    f_new: numpy.ndarray, shape=(1,...,M,...)
+        Interpolated and binned pdf
+
+    References
+    ----------
+    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
+           for Ensemble Visualization
+           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
+    """
+    # To have the needed axis always at the last index, as the number of indices is
+    # not safely propageted through the interpolation but the last element remains the last element
+    binned_pdf = np.swapaxes(binned_pdf, axis, -1)
+
+    # compute quantiles from quantile_resolution
+    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
+
+    # compute bin-mids from bin-edges
+    bin_mids = bin_center(edges)
+
+    # compute cdf values
+    cdfs = cdf_values(binned_pdf)
+
+    # compute ppf values at interpolation point, determine quantile and interpolate quantiles steps of [1]
+    ppfs = ppf_values(cdfs, bin_mids, m, mprime, quantiles)
+
+    # compute pdf values for all bins, evaluate interpolant PDF values step of [1]
+    pdf_values = reconstruct_pdf_values(quantiles, ppfs, edges)
+
+    # Renormalize pdf
+    normed_pdf_values = norm_pdf(pdf_values)
+
+    # Re-swap axes
+    return np.swapaxes(normed_pdf_values, axis, -1)
+
+
 @u.quantity_input(effective_area=u.m ** 2)
 def interpolate_effective_area_per_energy_and_fov(
     effective_area,
@@ -62,111 +277,15 @@ def interpolate_effective_area_per_energy_and_fov(
 
 
 def interpolate_energy_dispersion(
-    edges, hists, m, mprime, axis, quantile_resolution=1e-3
+    edges, binned_pdf, m, mprime, axis, quantile_resolution=1e-3
 ):
     """
-    Takes a grid of dispersion matrixes for a bunch of different parameters
+    Takes a grid of energy dispersions for a bunch of different parameters
     and interpolates it to given value of those parameters.
-    This function provides an adapted version of the quantile Interpolation introduced
-    in [1].
-    Instead of following this method closely, it implements different approaches to the
-    steps shown in Fig. 5 of [1].
-
-    Parameters
-    ----------
-    edges: numpy.ndarray, shape=(M+1)
-        Common array of bin-edges (along the abscissal ("x") axis) for the M bins of the input templates
-
-    hists: numpy.ndarray, shape=(N,...,M,...)
-        Array of M bin-heights (along the ordinate ("y") axis) for each of the 2 input templates.
-        The distributions to be interpolated (e.g. MigraEnerg for the IRFs Energy Dispersion) is expected to
-        be given at the dimension specified by axis.
-
-    m: numpy.ndarray, shape=(N, O)
-        Array of the N O-dimensional morphing parameter values corresponding to the N input templates. The pdf's qunatiles
-        are expected to vary linearly between these two reference points.
-
-    m_prime: numpy.ndarray, shape=(O)
-        Value for which the interpolation is performed (target point)
-
-    axis: int
-        Axis along which the pdfs used for interpolation are located
-
-    quantile_resolution: float
-        Spacing between the quantiles that are computed in the interpolation. Defaults to 1e-3.
-
-    Returns
-    -------
-    f_new: numpy.ndarray, shape=(1,...,M,...)
-        Interpolated histograms
-
-    References
-    ----------
-    .. [1] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions
-           for Ensemble Visualization
-           https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
     """
-    # To have the needed axis always at the last index, as the number of indices is
-    # not safely propageted through the interpolation but the last element remains the last element
-    hists = np.swapaxes(hists, axis, -1)
-
-    # Compute CDFs
-    cdfs = np.cumsum(hists, axis=-1)
-
-    cdfs = cdfs / np.expand_dims(np.max(cdfs, axis=-1), axis=-1)
-
-    quantiles = np.linspace(0, 1, int(np.round(1 / quantile_resolution, decimals=0)))
-
-    bin_mids = bin_center(edges)
-
-    # create ppf values from cdf samples via interpolation of the cdfs, determine quantile steps of [1]
-    ppfs_resampled = np.apply_along_axis(
-        lambda cdf: interp1d(
-            cdf, bin_mids, bounds_error=False, fill_value="extrapolate"
-        )(quantiles),
-        -1,
-        cdfs,
+    return interpolate_binned_pdf(
+        edges, binned_pdf, m, mprime, axis, quantile_resolution
     )
-
-    # nD interpolation of ppf values, interpolate quantiles step of [1]
-    ppf_interpolant = griddata(m, ppfs_resampled, mprime)
-
-    # recalculate pdf values, evaluate interpolant PDF values step of [1]
-    pdf_interpolant = np.diff(quantiles) / np.diff(ppf_interpolant, axis=-1)
-
-    # Unconventional solution to make this usable with np.apply_along_axis for readability
-    # The ppf bin-mids are computed since the pdf-values are derived through derivation
-    # from the ppf-values
-    xyconcat = np.concatenate(
-        (
-            ppf_interpolant[..., :-1] + np.diff(ppf_interpolant) / 2,
-            np.nan_to_num(pdf_interpolant),
-        ),
-        axis=-1,
-    )
-
-    # Interpolate pdf samples and evaluate at bin edges, weight with the bin_width to estimate
-    # correct bin height via the midpoint rule formulation of the trapezoidal rule
-    result = np.apply_along_axis(
-        lambda xy: np.diff(edges)
-        * np.nan_to_num(
-            interp1d(
-                xy[: int(len(xy) / 2)],
-                xy[int(len(xy) / 2) :],
-                bounds_error=False,
-                fill_value=(0, 0),
-            )(bin_mids)
-        ),
-        -1,
-        xyconcat,
-    )
-
-    # Renormalize histogram to a sum of 1
-    norm = np.sum(result, axis=-1)
-    norm = np.repeat(np.expand_dims(norm, -1), result.shape[-1], axis=-1)
-    norm[norm == 0] = np.nan
-
-    return np.swapaxes(np.nan_to_num(result / norm), axis, -1)
 
 
 def interpolate_psf_table(

--- a/pyirf/tests/test_binning.py
+++ b/pyirf/tests/test_binning.py
@@ -103,12 +103,12 @@ def test_create_histogram_table():
 
 
 def test_calculate_bin_indices():
-    from pyirf.binning import calculate_bin_indices
+    from pyirf.binning import calculate_bin_indices, OVERFLOW_INDEX, UNDERFLOW_INDEX
 
     bins = np.array([0, 1, 2])
     values = [0.5, 0.5, 1, 1.1, 1.9, 2, -1, 2.5]
 
-    true_idx = np.array([0, 0, 1, 1, 1, 2, -1, 2])
+    true_idx = np.array([0, 0, 1, 1, 1, OVERFLOW_INDEX, UNDERFLOW_INDEX, OVERFLOW_INDEX])
 
     assert np.all(calculate_bin_indices(values, bins) == true_idx)
 

--- a/pyirf/tests/test_cuts.py
+++ b/pyirf/tests/test_cuts.py
@@ -28,6 +28,10 @@ def test_calculate_percentile_cuts():
 
     values = np.append(dist1.rvs(size=N), dist2.rvs(size=N)) * u.deg
     bin_values = np.append(np.zeros(N), np.ones(N)) * u.m
+    bin_values.value[0] = -1
+    bin_values.value[1] = 2
+
+
     bins = [-0.5, 0.5, 1.5] * u.m
 
     cuts = calculate_percentile_cut(values, bin_values, bins, fill_value=np.nan * u.deg)

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -2,6 +2,132 @@ import pyirf.interpolation as interp
 import numpy as np
 import astropy.units as u
 import pytest
+from scipy.stats import norm
+from scipy.integrate import quad
+
+
+@pytest.fixture
+def data():
+    """Create common dataset containing binned Gaussians for interpolation testing. Binned PDFs sum to 1."""
+    bin_edges = np.linspace(-5, 30, 101)
+    distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
+
+    norm_1 = np.array(
+        [
+            quad(lambda x: distributions[0].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+    norm_2 = np.array(
+        [
+            quad(lambda x: distributions[1].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+    norm_3 = np.array(
+        [
+            quad(lambda x: distributions[2].pdf(x), low, up)[0]
+            for low, up in zip(bin_edges[:-1], bin_edges[1:])
+        ]
+    )
+
+    dataset = {
+        "bin_edges": bin_edges,
+        "means": np.array([5, 10, 15]),
+        "stds": np.array([1, 2, 3]),
+        "distributions": distributions,
+        "binned_pdfs": np.array([norm_1, norm_2, norm_3]),
+        "grid_points": np.array([1, 2, 3]),
+    }
+
+    return dataset
+
+
+def test_cdf_values(data):
+    from pyirf.interpolation import cdf_values
+
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+
+    # Assert empty histograms result in cdf containing zeros
+    assert np.all(cdf_values(np.zeros(shape=5)) == 0)
+
+    # Assert cdf is increasing or constant for actual pdfs
+    assert np.all(np.diff(cdf_est) >= 0)
+
+    # Assert cdf is capped at 1
+    assert np.max(cdf_est) == 1
+
+    # Assert estimated and true cdf are matching
+    assert np.allclose(cdf_est, data["distributions"][0].cdf(data["bin_edges"][1:]))
+
+
+def test_ppf_values(data):
+    from pyirf.interpolation import ppf_values, cdf_values
+
+    # Create quantiles, ignore the 0% and 100% quantile as they are analytically +- inf
+    quantiles = np.linspace(0, 1, 10)[1:-2]
+
+    # True ppf-values
+    ppf_true = data["distributions"][0].ppf(quantiles)
+
+    # Estimated ppf-values
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+    ppf_est = ppf_values(cdf_est, data["bin_edges"], quantiles)
+
+    # Assert truth and estimation match allowing for +- bin_width deviation
+    assert np.allclose(ppf_true, ppf_est, atol=np.diff(data["bin_edges"])[0])
+
+
+def test_pdf_from_ppf(data):
+    from pyirf.interpolation import ppf_values, cdf_values, pdf_from_ppf
+
+    # Create quantiles
+    quantiles = np.linspace(0, 1, 1000)
+
+    # Estimate ppf-values
+    cdf_est = cdf_values(data["binned_pdfs"][0])
+    ppf_est = ppf_values(cdf_est, data["bin_edges"], quantiles)
+
+    # Compute pdf_values
+    pdf_est = pdf_from_ppf(quantiles, ppf_est, data["bin_edges"])
+
+    # Assert pdf-values matching true pdf within +-1%
+    assert np.allclose(pdf_est, data["binned_pdfs"][0], atol=1e-2)
+
+
+def test_norm_pdf(data):
+    from pyirf.interpolation import norm_pdf
+
+    assert np.allclose(norm_pdf(2 * data["binned_pdfs"][0]), data["binned_pdfs"][0])
+    assert np.allclose(norm_pdf(np.zeros(5)), 0)
+
+
+def test_interpolate_binned_pdf(data):
+    from pyirf.interpolation import interpolate_binned_pdf
+    from pyirf.binning import bin_center
+
+    interp = interpolate_binned_pdf(
+        edges=data["bin_edges"],
+        binned_pdf=data["binned_pdfs"][[0, 2], :],
+        m=data["grid_points"][[0, 2]],
+        mprime=data["grid_points"][1],
+        axis=-1,
+        quantile_resolution=1e-3,
+    )
+
+    bin_mids = bin_center(data["bin_edges"])
+    bin_width = np.diff(data["bin_edges"])[0]
+
+    # Estimate mean and standart_deviation from interpolant
+    interp_mean = np.average(bin_mids, weights=interp)
+    interp_std = np.sqrt(np.average((bin_mids - interp_mean) ** 2, weights=interp))
+
+    print(interp_mean)
+
+    # Assert they match the truth within one bin of uncertainty
+    assert np.isclose(interp_mean, data["means"][1], atol=bin_width)
+    assert np.isclose(interp_std, data["stds"][1], atol=bin_width)
+
 
 def test_interpolate_effective_area_per_energy_and_fov():
     """Test of interpolating of effective area using dummy model files."""
@@ -9,11 +135,11 @@ def test_interpolate_effective_area_per_energy_and_fov():
     n_th = 1
     en = np.logspace(-2, 2, n_en)
     # applying a simple sigmoid function
-    aeff0 = 1.e4 / (1 + 1 / en**2) * u.Unit('m2')
+    aeff0 = 1.0e4 / (1 + 1 / en ** 2) * u.Unit("m2")
 
     # assume that for parameters 'x' and 'y' the Aeff scales x*y*Aeff0
     x = [0.9, 1.1]
-    y = [8., 11.5]
+    y = [8.0, 11.5]
     n_grid = len(x) * len(y)
     aeff = np.empty((n_grid, n_th, n_en))
     pars = np.empty((n_grid, 2))
@@ -23,140 +149,11 @@ def test_interpolate_effective_area_per_energy_and_fov():
             aeff[i_grid, 0, :] = aeff0 * xx * yy / 10
             pars[i_grid, :] = np.array([xx, yy])
             i_grid += 1
-    aeff *= u.Unit('m2')
+    aeff *= u.Unit("m2")
     pars0 = (1, 10)
-    min_aeff = 1 * u.Unit('m2')
-    aeff_interp = interp.interpolate_effective_area_per_energy_and_fov(aeff, pars, pars0, min_effective_area=min_aeff, method='linear')
+    min_aeff = 1 * u.Unit("m2")
+    aeff_interp = interp.interpolate_effective_area_per_energy_and_fov(
+        aeff, pars, pars0, min_effective_area=min_aeff, method="linear"
+    )
     # allowing for 3% accuracy except of close to the minimum value of Aeff
     assert np.allclose(aeff_interp[:, 0], aeff0, rtol=0.03, atol=min_aeff)
-
-
-def calc_mean_std(matrix, vals):
-    """Auxiliary function to compute mean and std from 'matrix' along an axis which values are in 'values'."""
-    n_en = matrix.shape[0]
-    means = np.empty(n_en)
-    stds = np.empty(n_en)
-    for i_en in np.arange(n_en):
-        w = matrix[i_en, :]
-        if np.sum(w) > 0:
-            means[i_en] = np.average(vals, weights=w)
-            stds[i_en] = np.sqrt(np.cov(vals, aweights=w))
-        else:  # we need to skip the empty columns
-            means[i_en] = -1
-            stds[i_en] = -1
-    return means, stds
-
-
-def test_interpolate_energy_dispersion():
-    """Test of interpolation of energy dispersion matrix using a simple dummy model."""
-    x = [0.9, 1.1]
-    y = [8., 11.5]
-    n_grid = len(x) * len(y)
-    n_offset = 1
-    n_en = 30
-    n_mig = 20
-    clip_level = 1.e-3
-
-    # define simple dummy bias and resolution model using two parameters x and y
-    def get_bias_std(i_en, x, y):
-        i_en = i_en + 3 * ((x - 1) + (y - 10.))
-        de = n_en - i_en
-        de[de < 0] = 0.
-        bias = de**0.5 + n_mig / 2
-        rms = 5 - 2 * (i_en / n_en)
-        bias[i_en < 3] = 2 * n_mig  # return high values to zero out part of the table
-        rms[i_en < 3] = 0
-        return bias, rms
-
-    en = np.arange(n_en)[:, np.newaxis]
-    mig = np.arange(n_mig)[np.newaxis, :]
-
-    # generate true values
-    interp_pars = (1, 10)
-    bias, sigma = get_bias_std(en, *interp_pars)
-    mig_true = np.exp(-(mig - bias)**2 / (2 * sigma**2))
-    mig_true[mig_true < clip_level] = 0
-
-    # generate a grid of migration matrixes
-    i_grid = 0
-    pars_all = np.empty((n_grid, 2))
-    mig_all = np.empty((n_grid, n_en, n_mig, n_offset))
-    for xx in x:
-        for yy in y:
-            bias, sigma = get_bias_std(en, xx, yy)
-            mig_all[i_grid, :, :, 0] = (np.exp(-(mig - bias)**2 / (2 * sigma**2)))
-            pars_all[i_grid, :] = (xx, yy)
-            i_grid += 1
-    # do the interpolation and compare the results with expected ones
-    mig_interp = interp.interpolate_energy_dispersion(mig_all, pars_all, interp_pars, method='linear')
-
-    # check if all the energy bins have normalization 1 or 0 (can happen because of empty bins)
-    sums = np.sum(mig_interp[:, :, 0], axis=1)
-    assert np.logical_or(np.isclose(sums, 0., atol=1.e-5), np.isclose(sums, 1., atol=1.e-5)).min()
-
-    # now check if we reconstruct the mean and sigma roughly fine after interpolation
-    bias0, stds0 = calc_mean_std(mig_true, mig[0, :])  # true
-    bias, stds = calc_mean_std(mig_interp[:, :, 0], mig[0, :])  # interpolated
-
-    # first remove the bins that are empty in true value
-    idxs = bias0 > 0
-    bias0 = bias0[idxs]
-    bias = bias[idxs]
-    stds0 = stds0[idxs]
-    stds = stds[idxs]
-    # allowing for a 0.6 bin size error on the interpolated values
-    assert np.allclose(bias, bias0, atol=0.6, rtol=0.)
-    assert np.allclose(stds, stds0, atol=0.6, rtol=0.)
-
-@pytest.mark.parametrize("cumulative", [False, True])
-def test_interpolate_psf_table(cumulative):
-    """Test of interpolation of PSF tables using a simple dummy model"""
-    from pyirf.utils import cone_solid_angle
-    x = [0.9, 1.1]
-    y = [8., 11.5]
-    n_grid = len(x) * len(y)
-    n_offset = 1
-    n_en = 30
-    n_src_off = 20
-
-    # define simple dummy model for angular resolution using two parameters x and y
-    def get_sigma(i_en, x, y):
-        i_en = i_en + 3 * ((x - 1) + (y - 10.))
-        return np.exp(-(i_en - 30) / 20)
-
-    en = np.arange(n_en)[:, np.newaxis, np.newaxis]
-    src_bins = np.arange(n_src_off + 1) * u.deg
-    omegas = np.diff(cone_solid_angle(src_bins))
-    src_off = np.arange(n_src_off)[np.newaxis, np.newaxis, :]
-
-    # generate true values
-    interp_pars = (1, 10)
-    sigma = get_sigma(en, *interp_pars)
-    psf_true = np.exp(-src_off**2 / (2 * sigma**2)) * u.Unit('sr-1')
-
-    # generate a grid of PSF tables
-    i_grid = 0
-    pars_all = np.empty((n_grid, 2))
-    psfs_all = np.empty((n_grid, n_en, n_offset, n_src_off))
-    for xx in x:
-        for yy in y:
-            sigma = get_sigma(en, xx, yy)
-            psfs_all[i_grid] = np.exp(-src_off**2 / (2 * sigma**2))
-            pars_all[i_grid, :] = (xx, yy)
-            i_grid += 1
-    psfs_all *= u.Unit('sr-1')
-
-    # do the interpolation and compare the results with expected ones
-    psf_interp = interp.interpolate_psf_table(psfs_all, pars_all, interp_pars, src_bins, cumulative=cumulative, method='linear')
-
-    # check if all the energy bins have normalization 1 or 0 (can happen because of empty bins)
-    sums = np.sum(psf_interp * omegas, axis=2)
-    assert np.logical_or(np.isclose(sums, 0., atol=1.e-5), np.isclose(sums, 1., atol=1.e-5)).min()
-
-    # check the first two moments of the distribution for every energy
-    mean_true, std_true = calc_mean_std(psf_true[:, 0, :], src_off[0, 0, :])
-    mean_interp, std_interp = calc_mean_std(psf_interp[:, 0, :], src_off[0, 0, :])
-
-    # check if they are within 10% + 0.25 of bin size
-    assert np.allclose(mean_interp, mean_true, atol=0.25, rtol=0.1)
-    assert np.allclose(std_interp, std_true, atol=0.25, rtol=0.1)

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -13,16 +13,14 @@ def data():
     distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
 
     # create binned pdfs by interpolation of bin content
-    norm_1 = distributions[0].cdf(bin_edges[1:]) - distributions[0].cdf(bin_edges[:-1])
-    norm_2 = distributions[1].cdf(bin_edges[1:]) - distributions[1].cdf(bin_edges[:-1])
-    norm_3 = distributions[2].cdf(bin_edges[1:]) - distributions[2].cdf(bin_edges[:-1])
+    binned_pdfs = np.array([np.diff(dist.cdf(bin_edges)) for dist in distributions])
 
     dataset = {
         "bin_edges": bin_edges,
         "means": np.array([5, 10, 15]),
         "stds": np.array([1, 2, 3]),
         "distributions": distributions,
-        "binned_pdfs": np.array([norm_1, norm_2, norm_3]),
+        "binned_pdfs": binned_pdfs,
         "grid_points": np.array([1, 2, 3]),
     }
 
@@ -107,8 +105,6 @@ def test_interpolate_binned_pdf(data):
     # Estimate mean and standart_deviation from interpolant
     interp_mean = np.average(bin_mids, weights=interp)
     interp_std = np.sqrt(np.average((bin_mids - interp_mean) ** 2, weights=interp))
-
-    print(interp_mean)
 
     # Assert they match the truth within one bin of uncertainty
     assert np.isclose(interp_mean, data["means"][1], atol=bin_width)

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -3,7 +3,6 @@ import numpy as np
 import astropy.units as u
 import pytest
 from scipy.stats import norm
-from scipy.integrate import quad
 
 
 @pytest.fixture

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -91,9 +91,9 @@ def test_interpolate_binned_pdf(data):
 
     interp = interpolate_binned_pdf(
         edges=data["bin_edges"],
-        binned_pdf=data["binned_pdfs"][[0, 2], :],
-        m=data["grid_points"][[0, 2]],
-        mprime=data["grid_points"][1],
+        binned_pdfs=data["binned_pdfs"][[0, 2], :],
+        grid_points=data["grid_points"][[0, 2]],
+        target_point=data["grid_points"][1],
         axis=-1,
         quantile_resolution=1e-3,
     )

--- a/pyirf/tests/test_interpolation.py
+++ b/pyirf/tests/test_interpolation.py
@@ -12,24 +12,10 @@ def data():
     bin_edges = np.linspace(-5, 30, 101)
     distributions = [norm(5, 1), norm(10, 2), norm(15, 3)]
 
-    norm_1 = np.array(
-        [
-            quad(lambda x: distributions[0].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
-    norm_2 = np.array(
-        [
-            quad(lambda x: distributions[1].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
-    norm_3 = np.array(
-        [
-            quad(lambda x: distributions[2].pdf(x), low, up)[0]
-            for low, up in zip(bin_edges[:-1], bin_edges[1:])
-        ]
-    )
+    # create binned pdfs by interpolation of bin content
+    norm_1 = distributions[0].cdf(bin_edges[1:]) - distributions[0].cdf(bin_edges[:-1])
+    norm_2 = distributions[1].cdf(bin_edges[1:]) - distributions[1].cdf(bin_edges[:-1])
+    norm_3 = distributions[2].cdf(bin_edges[1:]) - distributions[2].cdf(bin_edges[:-1])
 
     dataset = {
         "bin_edges": bin_edges,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require["all"] = list(set(extras_require["tests"] + extras_require["docs"
 
 setup(
     use_scm_version={"write_to": os.path.join("pyirf", "_version.py")},
-    packages=find_packages(),
+    packages=find_packages(exclude=['pyirf._dev_version']),
     install_requires=[
         "astropy>=4.0.2",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     use_scm_version={"write_to": os.path.join("pyirf", "_version.py")},
     packages=find_packages(),
     install_requires=[
-        "astropy~=4.0,>=4.0.2",
+        "astropy>=4.0.2",
         "matplotlib",
         "numpy>=1.18",
         "scipy",


### PR DESCRIPTION
Underflow and overflow are now marked with special values (intmin, intmax) that should prevent silent mistakes such as indexing the last entry because the underflow index was -1 before. Using undeflown values to index into a histogram now correctly raises an index error.

The benchmarks / calculate_percentile_cut functions no use the `nan<>` family of functions, so they ignore nan values in their input.