### PR TITLE
Improve under/overflow and nan handling in binning related functions

### DIFF
--- a/pyirf/benchmarks/angular_resolution.py
+++ b/pyirf/benchmarks/angular_resolution.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.table import Table
+from astropy.table import QTable
 from scipy.stats import norm
 import astropy.units as u
 
@@ -30,39 +30,32 @@ def angular_resolution(
 
     Returns
     -------
-    result : astropy.table.Table
-        Table containing the 68% containment of the angular
+    result : astropy.table.QTable
+        QTable containing the 68% containment of the angular
         distance distribution per each reconstructed energy bin.
     """
     # create a table to make use of groupby operations
-    table = Table(events[[f"{energy_type}_energy", "theta"]])
+    energy_key = f"{energy_type}_energy"
+    table = QTable(events[[energy_key, "theta"]])
 
-    table["bin_index"], valid = calculate_bin_indices(
-        table[f"{energy_type}_energy"].quantity, energy_bins
-    )
-    # ignore under / overflow
-    table = table[valid]
+    bin_index, valid = calculate_bin_indices(table[energy_key], energy_bins)
 
-    n_bins =  len(energy_bins) - 1
-    mask = (table["bin_index"] >= 0) & (table["bin_index"] < n_bins)
+    result = QTable()
+    result[f"{energy_key}_low"] = energy_bins[:-1]
+    result[f"{energy_key}_high"] = energy_bins[1:]
+    result[f"{energy_key}_center"] = 0.5 * (energy_bins[:-1] + energy_bins[1:])
+    result["n_events"] = 0
 
-    result = Table()
-    result[f"{energy_type}_energy_low"] = energy_bins[:-1]
-    result[f"{energy_type}_energy_high"] = energy_bins[1:]
-    result[f"{energy_type}_energy_center"] = 0.5 * (energy_bins[:-1] + energy_bins[1:])
+    key = "angular_resolution"
+    result[key] = u.Quantity(np.nan, table["theta"].unit)
 
-    result["angular_resolution"] = u.Quantity(np.nan, table["theta"].unit)
-
-    if not len(events):
-        # if we get an empty input (no selected events available)
-        # we return the table filled with NaNs
+    # if we get an empty input (no selected events available)
+    # we return the table filled with NaNs
+    if len(events) == 0:
         return result
 
     # use groupby operations to calculate the percentile in each bin
-    by_bin = table[mask].group_by("bin_index")
-
-    index = by_bin.groups.keys["bin_index"]
-    result["angular_resolution"][index] = by_bin["theta"].groups.aggregate(
-        lambda x: np.quantile(x, ONE_SIGMA_QUANTILE)
-    )
+    by_bin = table[valid].group_by(bin_index[valid])
+    for bin_idx, group in zip(by_bin.groups.keys, by_bin.groups):
+        result[key][bin_idx] = np.nanquantile(group["theta"], ONE_SIGMA_QUANTILE)
     return result

--- a/pyirf/benchmarks/energy_bias_resolution.py
+++ b/pyirf/benchmarks/energy_bias_resolution.py
@@ -26,7 +26,7 @@ def energy_resolution_absolute_68(rel_error):
     resolution: numpy.ndarray(dtype=float, ndim=1)
         Array containing the 68% intervals
     """
-    return np.nanpercentile(np.abs(rel_error), ONE_SIGMA_COVERAGE)
+    return np.nanquantile(np.abs(rel_error), ONE_SIGMA_COVERAGE)
 
 
 def inter_quantile_distance(rel_error):

--- a/pyirf/benchmarks/energy_bias_resolution.py
+++ b/pyirf/benchmarks/energy_bias_resolution.py
@@ -1,11 +1,13 @@
-from astropy.table import Table
 import numpy as np
 from scipy.stats import norm
+from astropy.table import QTable
+import astropy.units as u
 
-from ..binning import calculate_bin_indices
+from ..binning import calculate_bin_indices, UNDERFLOW_INDEX, OVERFLOW_INDEX
 
 
 NORM_LOWER_SIGMA, NORM_UPPER_SIGMA = norm(0, 1).cdf([-1, 1])
+ONE_SIGMA_COVERAGE = NORM_UPPER_SIGMA - NORM_LOWER_SIGMA
 MEDIAN = 0.5
 
 
@@ -24,8 +26,7 @@ def energy_resolution_absolute_68(rel_error):
     resolution: numpy.ndarray(dtype=float, ndim=1)
         Array containing the 68% intervals
     """
-    resolution = np.percentile(np.abs(rel_error), 68)
-    return resolution
+    return np.nanpercentile(np.abs(rel_error), ONE_SIGMA_COVERAGE)
 
 
 def inter_quantile_distance(rel_error):
@@ -44,8 +45,8 @@ def inter_quantile_distance(rel_error):
     resolution: numpy.ndarray(dtype=float, ndim=1)
         Array containing the resolution values.
     """
-    upper_sigma = np.percentile(rel_error, 100 * NORM_UPPER_SIGMA)
-    lower_sigma = np.percentile(rel_error, 100 * NORM_LOWER_SIGMA)
+    upper_sigma = np.nanquantile(rel_error, NORM_UPPER_SIGMA)
+    lower_sigma = np.nanquantile(rel_error, NORM_LOWER_SIGMA)
     resolution = 0.5 * (upper_sigma - lower_sigma)
     return resolution
 
@@ -76,29 +77,23 @@ def energy_bias_resolution(
 
     Returns
     -------
-    result : astropy.table.Table
-        Table containing the energy bias and resolution
+    result : astropy.table.QTable
+        QTable containing the energy bias and resolution
         per each bin in true energy.
     """
 
     # create a table to make use of groupby operations
-    table = Table(events[["true_energy", "reco_energy"]])
-    table["rel_error"] = (events["reco_energy"] / events["true_energy"]) - 1
+    table = QTable(events[["true_energy", "reco_energy"]], copy=False)
+    table["rel_error"] = (events["reco_energy"] / events["true_energy"]).to_value(u.one) - 1
 
-    table["bin_index"], valid = calculate_bin_indices(
-        table[f"{energy_type}_energy"].quantity, energy_bins
-    )
-    # ignore under/overflow events
-    table = table[valid]
+    energy_key = f"{energy_type}_energy"
 
-    n_bins = len(energy_bins) - 1
-    mask = (table["bin_index"] >= 0) & (table["bin_index"] < n_bins)
+    result = QTable()
+    result[f"{energy_key}_low"] = energy_bins[:-1]
+    result[f"{energy_key}_high"] = energy_bins[1:]
+    result[f"{energy_key}_center"] = 0.5 * (energy_bins[:-1] + energy_bins[1:])
 
-    result = Table()
-    result[f"{energy_type}_energy_low"] = energy_bins[:-1]
-    result[f"{energy_type}_energy_high"] = energy_bins[1:]
-    result[f"{energy_type}_energy_center"] = 0.5 * (energy_bins[:-1] + energy_bins[1:])
-
+    result["n_events"] = 0
     result["bias"] = np.nan
     result["resolution"] = np.nan
 
@@ -107,14 +102,17 @@ def energy_bias_resolution(
         # we return the table filled with NaNs
         return result
 
-    # use groupby operations to calculate the percentile in each bin
-    by_bin = table[mask].group_by("bin_index")
 
-    index = by_bin.groups.keys["bin_index"]
-    result["bias"][index] = by_bin["rel_error"].groups.aggregate(bias_function)
-    result["resolution"][index] = by_bin["rel_error"].groups.aggregate(
-        resolution_function
-    )
+    # use groupby operations to calculate the percentile in each bin
+    bin_index, valid = calculate_bin_indices(table[energy_key], energy_bins)
+    by_bin = table.group_by(bin_index)
+
+    # use groupby operations to calculate the percentile in each bin
+    by_bin = table[valid].group_by(bin_index[valid])
+    for bin_idx, group in zip(by_bin.groups.keys, by_bin.groups):
+        result["n_events"][bin_idx] = len(group)
+        result["bias"][bin_idx] = bias_function(group["rel_error"])
+        result["resolution"][bin_idx] = resolution_function(group["rel_error"])
     return result
 
 def energy_bias_resolution_from_energy_dispersion(

--- a/pyirf/benchmarks/tests/test_angular_resolution.py
+++ b/pyirf/benchmarks/tests/test_angular_resolution.py
@@ -41,10 +41,14 @@ def test_angular_resolution(unit):
 
     events['theta'] = events['theta'].to(unit)
 
+    # add nans to test if nans are ignored
+    events["true_energy"].value[500] = np.nan
+    events["true_energy"].value[1500] = np.nan
+
     ang_res = angular_resolution(
         events,
         [1, 10, 100] * u.TeV,
-    )['angular_resolution'].quantity
+    )['angular_resolution']
 
     assert len(ang_res) == 2
     assert u.isclose(ang_res[0], TRUE_RES_1 * u.deg, rtol=0.05)

--- a/pyirf/benchmarks/tests/test_bias_resolution.py
+++ b/pyirf/benchmarks/tests/test_bias_resolution.py
@@ -21,6 +21,14 @@ def test_empty_bias_resolution():
     assert np.all(np.isnan(table["bias"]))
     assert np.all(np.isnan(table["resolution"]))
 
+
+def test_absolute_68():
+    from pyirf.benchmarks.energy_bias_resolution import energy_resolution_absolute_68
+    rng = np.random.default_rng(0)
+    values = rng.normal(0, 1, 1000)
+    assert np.isclose(energy_resolution_absolute_68(values), 1, rtol=0.01)
+
+
 def test_energy_bias_resolution():
     from pyirf.benchmarks import energy_bias_resolution
 

--- a/pyirf/cuts.py
+++ b/pyirf/cuts.py
@@ -1,9 +1,9 @@
 import numpy as np
 from astropy.table import Table, QTable
-from scipy.ndimage.filters import gaussian_filter1d
+from scipy.ndimage import gaussian_filter1d
 import astropy.units as u
 
-from .binning import calculate_bin_indices, bin_center
+from .binning import calculate_bin_indices, bin_center, UNDERFLOW_INDEX, OVERFLOW_INDEX
 
 __all__ = [
     'calculate_percentile_cut',
@@ -26,7 +26,7 @@ def calculate_percentile_cut(
         The values for which the cut should be calculated
     bin_values: ``~numpy.ndarray`` or ``~astropy.units.Quantity``
         The values used to sort the ``values`` into bins
-    bins: ``~numpy.ndarray`` or ``~astropy.units.Quantity``
+    edges: ``~numpy.ndarray`` or ``~astropy.units.Quantity``
         Bin edges
     fill_value: float or quantity
         Value for bins with less than ``min_events``,
@@ -45,61 +45,43 @@ def calculate_percentile_cut(
         Bins with less events than this number are replaced with ``fill_value``
     """
     # create a table to make use of groupby operations
-    table = Table({"values": values, "bin_values": bin_values}, copy=False)
+    table = QTable({"values": values, "bin_values": bin_values}, copy=False)
     unit = table["values"].unit
 
     # make sure units match
     if unit is not None:
         fill_value = u.Quantity(fill_value).to(unit)
 
-    table["bin_index"], valid = calculate_bin_indices(table["bin_values"].quantity, bins)
-
-    # remove events outside of binning
-    table = table[valid]
+    bin_index, valid = calculate_bin_indices(table["bin_values"], bins)
+    by_bin = table[valid].group_by(bin_index[valid])
 
     cut_table = QTable()
     cut_table["low"] = bins[:-1]
     cut_table["high"] = bins[1:]
     cut_table["center"] = bin_center(bins)
-    cut_table["cut"] = fill_value
+    cut_table["n_events"] = 0
+    cut_table["cut"] = np.asanyarray(fill_value, values.dtype)
 
-    # use groupby operations to calculate the percentile in each bin
-    by_bin = table.group_by("bin_index")
+    for bin_idx, group in zip(by_bin.groups.keys, by_bin.groups):
+        # replace bins with too few events with fill_value
+        n_events = len(group)
+        cut_table["n_events"][bin_idx] = n_events
 
-    # fill only the non-empty bins
-    cut = by_bin["values"].groups.aggregate(lambda g: np.percentile(g, percentile))
-    if unit is not None:
-        cut = cut.quantity.to(unit)
+        if n_events < min_events:
+            cut_table["cut"][bin_idx] = fill_value
+        else:
+            value = np.nanpercentile(group["values"], percentile)
+            if min_value is not None or max_value is not None:
+                value = np.clip(value, min_value, max_value)
 
-    # replace bins with too few events with fill_value
-    n_events = by_bin["values"].groups.aggregate(len)
-    cut[n_events < min_events] = fill_value
-
-    # assign to full table, index lookup needed in case of empty bins
-    cut_table["cut"][by_bin.groups.keys["bin_index"]] = cut
-
-    if min_value is not None:
-        if unit is not None:
-            min_value = u.Quantity(min_value).to(unit)
-        invalid = cut_table["cut"] < min_value
-        cut_table["cut"] = np.where(invalid, min_value, cut_table["cut"])
-
-    if max_value is not None:
-        if unit is not None:
-            max_value = u.Quantity(max_value).to(unit)
-        invalid = cut_table["cut"] > max_value
-        cut_table["cut"] = np.where(invalid, max_value, cut_table["cut"])
+            cut_table["cut"][bin_idx] = value
 
     if smoothing is not None:
-        if unit is not None:
-            cut = cut_table['cut'].to_value(unit)
-
-        cut = gaussian_filter1d(cut, smoothing, mode='nearest')
-
-        if unit is not None:
-            cut = u.Quantity(cut, unit=unit, copy=False)
-
-        cut_table['cut'] = cut
+        cut_table['cut'].value[:] = gaussian_filter1d(
+            cut_table["cut"].value,
+            smoothing,
+            mode='nearest',
+        )
 
     return cut_table
 

--- a/pyirf/tests/test_binning.py
+++ b/pyirf/tests/test_binning.py
@@ -110,13 +110,14 @@ def test_create_histogram_table():
 
 
 def test_calculate_bin_indices():
-    from pyirf.binning import calculate_bin_indices
+    from pyirf.binning import calculate_bin_indices, OVERFLOW_INDEX, UNDERFLOW_INDEX
 
     bins = np.array([0, 1, 2])
     values = [0.5, 0.5, 1, 1.1, 1.9, 2, -1, 2.5]
 
     true_idx = np.array([0, 0, 1, 1, 1, 2, -1, 2])
     true_valid = np.array([True, True, True, True, True, False, False, False])
+    true_idx = np.array([0, 0, 1, 1, 1, OVERFLOW_INDEX, UNDERFLOW_INDEX, OVERFLOW_INDEX])
 
     idx, valid = calculate_bin_indices(values, bins)
     assert np.all(idx == true_idx)


### PR DESCRIPTION
Underflow and overflow are now marked with special values (intmin, intmax) that should prevent silent mistakes such as indexing the last entry because the underflow index was -1 before. Using undeflown values to index into a histogram now correctly raises an index error.

The benchmarks / calculate_percentile_cut functions no use the `nan<>` family of functions, so they ignore nan values in their input.