### PR TITLE
Fix unit handling of powerlaw

### DIFF
--- a/pyirf/spectral.py
+++ b/pyirf/spectral.py
@@ -91,13 +91,17 @@ class PowerLaw:
     )
     def __init__(self, normalization, index, e_ref=1 * u.TeV):
         """Create a new PowerLaw spectrum"""
+        if index > 0:
+            raise ValueError(f'Index must be < 0, got {index}')
+
         self.normalization = normalization
         self.index = index
         self.e_ref = e_ref
 
     @u.quantity_input(energy=u.TeV)
     def __call__(self, energy):
-        return self.normalization * (energy / self.e_ref) ** self.index
+        e = (energy / self.e_ref).to_value(u.one)
+        return self.normalization * e**self.index
 
     @classmethod
     @u.quantity_input(obstime=u.hour, e_ref=u.TeV)

--- a/pyirf/tests/test_spectral.py
+++ b/pyirf/tests/test_spectral.py
@@ -54,3 +54,22 @@ def test_powerlaw_integrate_cone(outer, expected):
     assert u.isclose(integrated.normalization, diffuse_flux.normalization * expected)
     assert integrated.index == diffuse_flux.index
     assert integrated.e_ref == diffuse_flux.e_ref
+
+
+def test_powerlaw():
+    from pyirf.spectral import PowerLaw
+
+    with pytest.raises(TypeError):
+        PowerLaw(normalization=1e-10, index=-2)
+
+    with pytest.raises(u.UnitsError):
+        PowerLaw(normalization=1e-10 / u.TeV, index=-2)
+
+    with pytest.raises(ValueError):
+        PowerLaw(normalization=1e-10 / u.TeV / u.m**2 / u.s, index=2)
+
+    # check we get a reasonable unit out of astropy independent of input unit
+    unit = u.TeV**-1 * u.m**-2 * u.s**-1
+    power_law = PowerLaw(1e-10 * unit, -2.65)
+    assert power_law(1 * u.TeV).unit == unit
+    assert power_law(1 * u.GeV).unit == unit


### PR DESCRIPTION
This fixes an issue that the astropy exponentiation does not remove the units leading to unexpected results:

```
In [2]: (u.GeV / u.TeV)**-2.67
Out[2]: Unit("TeV(267/100) / GeV(267/100)")
```