### PR TITLE
Move setuptools-scm to devdeps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
 
 # nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,11 @@ extras_require = {
     ],
     "gammapy": [
         gammapy,
-    ]
+    ],
 }
+extras_require["dev"] = extras_require["tests"] + [
+    "setuptools_scm",
+]
 
 all_extras = set()
 for extra in extras_require.values():
@@ -44,7 +47,6 @@ setup(
         "numpy>=1.18",
         "scipy",
         "tqdm",
-        "setuptools_scm",
     ],
     include_package_data=True,
     extras_require=extras_require,


### PR DESCRIPTION
It's is not required in normal installations since we ship the version info