### PR TITLE
Delete wrongfully entered newsfragments

### DIFF
--- a/docs/changes/180.feature.rst
+++ b/docs/changes/180.feature.rst
@@ -1,2 +1,0 @@
-Add interpolation function for RAD_MAX tables. 
-There is now a ``interpolate_rad_max`` function in ``pyirf.interpolation`` that is a simple wrapper around ``scipy.interpolate.griddata``.

--- a/docs/changes/200.bugfix.rst
+++ b/docs/changes/200.bugfix.rst
@@ -1,1 +1,0 @@
-Units are now correctly handled in ``pyirf.spectral.PowerLaw``.

--- a/docs/changes/202.maintenance.rst
+++ b/docs/changes/202.maintenance.rst
@@ -1,1 +1,0 @@
-Updates ``gammapy`` dependency to version 1.


### PR DESCRIPTION
#207 introduced some news fragments of already released changes. These are now wrongfully drafted for the next release and are thus removed.