### PR TITLE
Add fixture containing some prod5 irfs from zenodo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/cache@v3 
         id: cache-irfs
         with:
-          path: ./pyirf/recources/irfs
-          key: ${{ runner.OS }}-irf-cache-${{ hashFiles('*.fit.gz') }}
+          path: ./irfs
+          key: irf-cache-${{ hashFiles('**/*.fits.gz') }}
 
       # make sure we have version info
       - run: git fetch --tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/cache@v3 
+        id: cache-irfs
+        with:
+          path: ./pyirf/recources/irfs
+          key: ${{ runner.OS }}-irf-cache-${{ hashFiles('*.fit.gz') }}
+
       # make sure we have version info
       - run: git fetch --tags
 
@@ -43,6 +49,10 @@ jobs:
       - name: Check README
         run: |
           rst-lint README.rst
+
+      - name: Get IRF Files
+        if: steps.cache-irfs.outputs.cache-hit != 'true'
+        run: python download_irfs.py
 
       - name: Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         id: cache-irfs
         with:
           path: ./irfs
-          key: irf-cache-${{ hashFiles('**/*.fits.gz') }}
+          key: irf-cache
 
       # make sure we have version info
       - run: git fetch --tags

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IRFs downloaded for tests 
+irfs/

--- a/docs/changes/211.maintenance.rst
+++ b/docs/changes/211.maintenance.rst
@@ -1,0 +1,8 @@
+Add a fixture containing three IRFs from `the prod5 IRF data-release <https://zenodo.org/record/5499840>`
+for unit testing. Specifically the fixture contains the contents of:
+* Prod5-North-20deg-AverageAz-4LSTs.180000s-v0.1.fits.gz.
+* Prod5-North-40deg-AverageAz-4LSTs.180000s-v0.1.fits.gz
+* Prod5-North-60deg-AverageAz-4LSTs.180000s-v0.1.fits.gz
+
+The user has to download these irfs to ``pyirf/resources/irfs/`` using ``download_irfs.py``,
+github's CI does so automatically and caches them for convenience.

--- a/docs/changes/211.maintenance.rst
+++ b/docs/changes/211.maintenance.rst
@@ -4,5 +4,5 @@ for unit testing. Specifically the fixture contains the contents of:
 * Prod5-North-40deg-AverageAz-4LSTs.180000s-v0.1.fits.gz
 * Prod5-North-60deg-AverageAz-4LSTs.180000s-v0.1.fits.gz
 
-The user has to download these irfs to ``pyirf/resources/irfs/`` using ``download_irfs.py``,
+The user has to download these irfs to ``irfs/`` using ``download_irfs.py``,
 github's CI does so automatically and caches them for convenience.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ To install a released version, just install the ``pyirf`` package using
 
 .. code-block:: bash
 
-    pip install pyirf
+    $ pip install pyirf
 
 or add it to the dependencies of your project.
 
@@ -38,7 +38,7 @@ These requirements can also be enabled by installing the ``all`` extra:
 
 .. code-block:: bash
 
-    pip install -e '.[all]'  # or [docs,tests] to install them separately
+    $ pip install -e '.[all]'  # or [docs,tests] to install them separately
 
 
 You should isolate your pyirf development environment from the rest of your system.
@@ -47,6 +47,21 @@ Either by using a virtual environment or by using ``conda`` environments.
 
 .. code-block:: bash
 
-   conda env create -f environment.yml
-   conda activate pyirf
-   pip install -e '.[all]'
+   $ conda env create -f environment.yml
+   $ conda activate pyirf
+   $ pip install -e '.[all]'
+
+In order to have passing unit-tests you have to download some CTA IRFs 
+from `zenodo <https://zenodo.org/record/5499840>`. Simply run 
+
+.. code-block:: bash 
+
+   $ python download_irfs.py 
+
+which will download and unpack three IRF files to ``irfs/``.
+
+Run the tests to make sure everything is OK: 
+
+.. code-block:: bash
+
+   $ pytest

--- a/download_irfs.py
+++ b/download_irfs.py
@@ -6,26 +6,30 @@ from zipfile import ZipFile
 
 import requests
 
-r = requests.get(
-    "https://zenodo.org/record/5499840/files/cta-prod5-zenodo-fitsonly-v0.1.zip?download=1"
-)
-r.raise_for_status()
+def download_irfs():
+    r = requests.get(
+        "https://zenodo.org/record/5499840/files/cta-prod5-zenodo-fitsonly-v0.1.zip?download=1"
+    )
+    r.raise_for_status()
 
 
-obstime = 50 * 3600
+    obstime = 50 * 3600
 
 
-tarball = "fits/CTA-Performance-prod5-v0.1-North-LSTSubArray-{zenith:d}deg.FITS.tar.gz"
-irf_file = "Prod5-North-{zenith:d}deg-AverageAz-4LSTs.{obstime}s-v0.1.fits.gz"
+    tarball = "fits/CTA-Performance-prod5-v0.1-North-LSTSubArray-{zenith:d}deg.FITS.tar.gz"
+    irf_file = "Prod5-North-{zenith:d}deg-AverageAz-4LSTs.{obstime}s-v0.1.fits.gz"
 
-output_dir = Path("./pyirf/resources/irfs")
-output_dir.mkdir(exist_ok=True)
+    output_dir = Path(__file__).parent / "irfs"
+    output_dir.mkdir(exist_ok=True)
 
-for zenith in (20, 40, 60):
-    with ZipFile(BytesIO(r.content)) as zipfile:
-        with tarfile.open(
-            fileobj=zipfile.open(tarball.format(zenith=zenith), mode="r")
-        ) as tar:
-            tar.extract(
-                irf_file.format(zenith=zenith, obstime=obstime), path=output_dir
-            )
+    for zenith in (20, 40, 60):
+        with ZipFile(BytesIO(r.content)) as zipfile:
+            with tarfile.open(
+                fileobj=zipfile.open(tarball.format(zenith=zenith), mode="r")
+            ) as tar:
+                tar.extract(
+                    irf_file.format(zenith=zenith, obstime=obstime), path=output_dir
+                )
+
+if __name__ == '__main__':
+    download_irfs()

--- a/download_irfs.py
+++ b/download_irfs.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+import tarfile
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+import requests
+
+r = requests.get(
+    "https://zenodo.org/record/5499840/files/cta-prod5-zenodo-fitsonly-v0.1.zip?download=1"
+)
+r.raise_for_status()
+
+
+obstime = 50 * 3600
+
+
+tarball = "fits/CTA-Performance-prod5-v0.1-North-LSTSubArray-{zenith:d}deg.FITS.tar.gz"
+irf_file = "Prod5-North-{zenith:d}deg-AverageAz-4LSTs.{obstime}s-v0.1.fits.gz"
+
+output_dir = Path("./pyirf/resources/irfs")
+output_dir.mkdir(exist_ok=True)
+
+for zenith in (20, 40, 60):
+    with ZipFile(BytesIO(r.content)) as zipfile:
+        with tarfile.open(
+            fileobj=zipfile.open(tarball.format(zenith=zenith), mode="r")
+        ) as tar:
+            tar.extract(
+                irf_file.format(zenith=zenith, obstime=obstime), path=output_dir
+            )

--- a/download_irfs.py
+++ b/download_irfs.py
@@ -6,17 +6,18 @@ from zipfile import ZipFile
 
 import requests
 
+
 def download_irfs():
     r = requests.get(
         "https://zenodo.org/record/5499840/files/cta-prod5-zenodo-fitsonly-v0.1.zip?download=1"
     )
     r.raise_for_status()
 
-
     obstime = 50 * 3600
 
-
-    tarball = "fits/CTA-Performance-prod5-v0.1-North-LSTSubArray-{zenith:d}deg.FITS.tar.gz"
+    tarball = (
+        "fits/CTA-Performance-prod5-v0.1-North-LSTSubArray-{zenith:d}deg.FITS.tar.gz"
+    )
     irf_file = "Prod5-North-{zenith:d}deg-AverageAz-4LSTs.{obstime}s-v0.1.fits.gz"
 
     output_dir = Path(__file__).parent / "irfs"
@@ -31,5 +32,6 @@ def download_irfs():
                     irf_file.format(zenith=zenith, obstime=obstime), path=output_dir
                 )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     download_irfs()

--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -3,11 +3,17 @@ import pathlib
 import pytest
 from gammapy.irf import load_irf_dict_from_file
 
-PROD5_IRF_PATH = pathlib.Path(__file__).parent / "resources/irfs/"
+PROD5_IRF_PATH = pathlib.Path(__file__).parent.parent / "irfs/"
 
 
 @pytest.fixture(scope="session")
 def prod5_irfs():
+    if not PROD5_IRF_PATH.exists():
+        pytest.fail(
+            "Test IRF files missing, you need to download them using " 
+            "`python download_irfs.py` in pyirfs root directory."
+            )
+
     irfs = [
         load_irf_dict_from_file(irf_file)
         for irf_file in PROD5_IRF_PATH.glob("*.fits.gz")

--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -1,0 +1,21 @@
+import pathlib
+
+import pytest
+from gammapy.irf import load_irf_dict_from_file
+
+PROD5_IRF_PATH = pathlib.Path(__file__).parent / "resources/irfs/"
+
+
+@pytest.fixture(scope="session")
+def prod5_irfs():
+    irfs = [
+        load_irf_dict_from_file(irf_file)
+        for irf_file in PROD5_IRF_PATH.glob("*.fits.gz")
+    ]
+
+    assert len(irfs) == 3
+    for key in ["aeff", "psf", "edisp"]:
+        for irf in irfs:
+            assert key in irf
+
+    return irfs

--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -10,9 +10,9 @@ PROD5_IRF_PATH = pathlib.Path(__file__).parent.parent / "irfs/"
 def prod5_irfs():
     if not PROD5_IRF_PATH.exists():
         pytest.fail(
-            "Test IRF files missing, you need to download them using " 
+            "Test IRF files missing, you need to download them using "
             "`python download_irfs.py` in pyirfs root directory."
-            )
+        )
 
     irfs = [
         load_irf_dict_from_file(irf_file)

--- a/pyirf/tests/test_resources.py
+++ b/pyirf/tests/test_resources.py
@@ -1,0 +1,3 @@
+def test_prod5_irfs(prod5_irfs):
+    assert len(prod5_irfs) == 3
+    assert "edisp" in prod5_irfs[0]

--- a/pyirf/tests/test_resources.py
+++ b/pyirf/tests/test_resources.py
@@ -1,3 +1,0 @@
-def test_prod5_irfs(prod5_irfs):
-    assert len(prod5_irfs) == 3
-    assert "edisp" in prod5_irfs[0]


### PR DESCRIPTION
This intends to add a fixture for future unit-testing containing some of the prod5 irfs published on [zenodo](https://zenodo.org/record/5499840). Since downloading the files each time a new github action is triggered is time-consuming we try to cache things using github's action/cache.

ATM this PR is intended to do some live-testing with github's CI. I undraft it once everything works.
Edit: Everything should be working now