### PR TITLE
Use float64 in li_ma_significance

### DIFF
--- a/pyirf/statistics.py
+++ b/pyirf/statistics.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .utils import is_scalar
 
-__all__  = ['li_ma_significance']
+__all__ = ["li_ma_significance"]
 
 
 def li_ma_significance(n_on, n_off, alpha=0.2):
@@ -32,8 +32,11 @@ def li_ma_significance(n_on, n_off, alpha=0.2):
 
     scalar = is_scalar(n_on)
 
-    n_on = np.array(n_on, copy=False, ndmin=1)
-    n_off = np.array(n_off, copy=False, ndmin=1)
+    # Cast everything into float64 to avoid numeric instabilties
+    # when multiplying very small and very big numbers to get t1 and t2
+    n_on = np.array(n_on, copy=False, ndmin=1, dtype=np.float64)
+    n_off = np.array(n_off, copy=False, ndmin=1, dtype=np.float64)
+    alpha = np.float64(alpha)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         p_on = n_on / (n_on + n_off)

--- a/pyirf/statistics.py
+++ b/pyirf/statistics.py
@@ -19,7 +19,7 @@ def li_ma_significance(n_on, n_off, alpha=0.2):
     ----------
     n_on: integer or array like
         Number of events for the on observations
-    n_off: integer of array like
+    n_off: integer or array like
         Number of events for the off observations
     alpha: float
         Ratio between the on region and the off region size or obstime.

--- a/pyirf/tests/test_statistics.py
+++ b/pyirf/tests/test_statistics.py
@@ -11,7 +11,7 @@ def test_lima():
 
 
 def test_lima_gammapy():
-    pytest.importorskip('gammapy')
+    pytest.importorskip("gammapy")
     from gammapy.stats import WStatCountsStatistic
     from pyirf.statistics import li_ma_significance
 
@@ -21,3 +21,19 @@ def test_lima_gammapy():
     for n_on, n_off, alpha in zip(n_ons, n_offs, alphas):
         sig_gammapy = WStatCountsStatistic(n_on, n_off, alpha).sqrt_ts
         assert np.isclose(li_ma_significance(n_on, n_off, alpha), sig_gammapy)
+
+
+def test_lima_accuracy():
+    from pyirf.statistics import li_ma_significance
+
+    noff = 1e7
+    nexcess = 1e4
+
+    res_f64 = li_ma_significance(
+        np.float64(noff + nexcess), np.float64(noff / 0.2), 0.2
+    )
+    res_f32 = li_ma_significance(
+        np.float32(noff + nexcess), np.float32(noff / 0.2), 0.2
+    )
+
+    assert np.isclose(res_f64, res_f32)


### PR DESCRIPTION
Fixes #205 by forcefully casting everything to float64 in `li_ma_significance` as proposed in the issue. The problem arises when computing 

```
t1 = n_on * np.log(((1 + alpha) / alpha) * p_on)
t2 = n_off * np.log((1 + alpha) * p_off)
```

where {n_on, n_off} is some big number and the logarithm has to be computed near 1, thus exceeding float32 accuracy. Multiplying this, the rounding error for the log produces a result off in O(1) which propagates to the result. Downside is ofc. that all results regardless of input dtype end up being float64.

Other option would be to use gammapy's WStatCountsStatistic instead of having our own version of this, but it seems that gammapy also returns f64 regardless of input dtypes.