### PR TITLE
Parse zenith angle of irfs

### DIFF
--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -1,6 +1,9 @@
 import pathlib
+import re
 
 import pytest
+from astropy.units import Quantity
+
 from gammapy.irf import load_irf_dict_from_file
 
 PROD5_IRF_PATH = pathlib.Path(__file__).parent.parent / "irfs/"
@@ -14,14 +17,16 @@ def prod5_irfs():
             "`python download_irfs.py` in pyirfs root directory."
         )
 
-    irfs = [
-        load_irf_dict_from_file(irf_file)
+    irfs = {
+        Quantity(re.search("\d{2}deg", str(irf_file)).group()): load_irf_dict_from_file(
+            irf_file
+        )
         for irf_file in PROD5_IRF_PATH.glob("*.fits.gz")
-    ]
+    }
 
     assert len(irfs) == 3
     for key in ["aeff", "psf", "edisp"]:
-        for irf in irfs:
+        for irf in irfs.values():
             assert key in irf
 
     return irfs

--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -19,7 +19,7 @@ def prod5_irfs():
 
     # Get dict of {ZEN_PNT, IRF} pairs for each file in ./irfs
     irfs = {
-        Quantity(re.search("\d{2}deg", str(irf_file)).group()): load_irf_dict_from_file(
+        Quantity(re.search(r"\d{2}deg", str(irf_file)).group()): load_irf_dict_from_file(
             irf_file
         )
         for irf_file in PROD5_IRF_PATH.glob("*.fits.gz")

--- a/pyirf/conftest.py
+++ b/pyirf/conftest.py
@@ -17,6 +17,7 @@ def prod5_irfs():
             "`python download_irfs.py` in pyirfs root directory."
         )
 
+    # Get dict of {ZEN_PNT, IRF} pairs for each file in ./irfs
     irfs = {
         Quantity(re.search("\d{2}deg", str(irf_file)).group()): load_irf_dict_from_file(
             irf_file
@@ -29,4 +30,5 @@ def prod5_irfs():
         for irf in irfs.values():
             assert key in irf
 
-    return irfs
+    # Sort dict by zenith angle
+    return dict(sorted(irfs.items()))


### PR DESCRIPTION
Since the prod5 IRFs somehow do not contain metadata indicating the telescope pointing, this PR parses them from the input paths and now returns a dict in the form of `{astropy.units.Quantity(ZEN_PNT): gammapy.irf}` as fixture value in the `prof5_irfs` fixture.

This should most likely be regarded as temporarily necessity until IRFs with pointing meta-data become available publicly. 