### PR TITLE
Use nanmedian by default for energy_bias_resolution

### DIFF
--- a/pyirf/benchmarks/energy_bias_resolution.py
+++ b/pyirf/benchmarks/energy_bias_resolution.py
@@ -55,7 +55,7 @@ def energy_bias_resolution(
     events,
     energy_bins,
     energy_type="true",
-    bias_function=np.median,
+    bias_function=np.nanmedian,
     resolution_function=inter_quantile_distance,
 ):
     """


### PR DESCRIPTION
In [#nan](https://github.com/cta-observatory/pyirf/pull/199), most functions were changed to ignore nans, e.g. in the predicted energy.

Most... the default for `bias_function` was missed