### PR TITLE
Add Moment Morph Interpolation

### DIFF
--- a/docs/changes/229.feature.rst
+++ b/docs/changes/229.feature.rst
@@ -1,0 +1,2 @@
+Add Moment Morphing as second interpolation method able to handle discretized PDF 
+components of IRFs.

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -17,6 +17,7 @@ from .component_estimators import (
     RadMaxEstimator,
 )
 from .griddata_interpolator import GridDataInterpolator
+from .moment_morph_interpolator import MomentMorphInterpolator
 from .quantile_interpolator import QuantileInterpolator
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "DiscretePDFComponentEstimator",
     "DiscretePDFInterpolator",
     "GridDataInterpolator",
+    "MomentMorphInterpolator",
     "ParametrizedComponentEstimator",
     "ParametrizedInterpolator",
     "QuantileInterpolator",

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -11,7 +11,7 @@ __all__ = [
 
 def estimate_mean_std(bin_edges, bin_contents):
     """
-    Function to roughly estimate mean and standart deviation from a histogram.
+    Function to roughly estimate mean and standard deviation from a histogram.
 
     Parameters
     ----------
@@ -25,7 +25,7 @@ def estimate_mean_std(bin_edges, bin_contents):
     mean: np.ndarray, shape=(N, ...)
         Estimated mean for each input template
     std: np.ndarray, shape=(N, ...)
-        Estimated standart deviation for each input template. Set to width/2 if only one bin in
+        Estimated standard deviation for each input template. Set to width/2 if only one bin in
         the input template is =/= 0
     """
     # Create an 2darray where the 1darray mids is repeated n_template times
@@ -216,12 +216,12 @@ def moment_morph_estimation(bin_edges, bin_contents, coefficients):
 
     # Transform mean and std as in eq. (11) and (12) in [1]
     # cs = np.broadcast_to(cs, mus.shape)
-    mu_strich = np.sum(coefficients * mus, axis=0)
-    sig_strich = np.sum(coefficients * sigs, axis=0)
+    mu_prime = np.sum(coefficients * mus, axis=0)
+    sig_prime = np.sum(coefficients * sigs, axis=0)
 
     # Compute slope and offset as in eq. (14) and (15) in [1]
-    aij = sigs / sig_strich
-    bij = mus - mu_strich * aij
+    aij = sigs / sig_prime
+    bij = mus - mu_prime * aij
 
     # Transformation as in eq. (13) in [1]
     mids = np.broadcast_to(bin_mids, bin_contents.shape)
@@ -257,7 +257,7 @@ def moment_morph_estimation(bin_edges, bin_contents, coefficients):
 class MomentMorphInterpolator(DiscretePDFInterpolator):
     def __init__(self, grid_points, bin_edges, bin_contents):
         """
-        Actual interpolator class utilizing MomentMorphInterpolations.
+        Interpolator class using moment morphing.
 
         Parameters
         ----------
@@ -288,7 +288,7 @@ class MomentMorphInterpolator(DiscretePDFInterpolator):
 
     def _interpolate1D(self, target_point):
         """
-        Function to find target inside 1D self.grid_points and creating a Base1DMomentMorphInterpolator
+        Function to find target inside 1D self.grid_points and interpolate 
         on this subset.
         """
         target_bin = np.digitize(target_point.squeeze(), self.grid_points.squeeze())
@@ -306,7 +306,7 @@ class MomentMorphInterpolator(DiscretePDFInterpolator):
 
     def _interpolate2D(self, target_point):
         """
-        Function to find target inside 2D self.grid_points and creating a Base2DTriangularMomentMorphInterpolator
+        Function to find target inside 2D self.grid_points and interpolate
         on this subset.
         """
         simplex_inds = self.triangulation.simplices[

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -124,9 +124,7 @@ def linesegment_1D_interpolation_coefficients(grid_points, target_point):
     m_ij = (grid_points - m0) ** j
 
     # Compute coefficients, eq. (6) from [1]
-    return np.einsum(
-        "...j, ji -> ...i", ((target_point - m0) ** j), np.linalg.inv(m_ij)
-    )
+    return np.einsum("...j, ji -> ...i", (target_point - m0) ** j, np.linalg.inv(m_ij))
 
 
 def baryzentric_2D_interpolation_coefficients(grid_points, target_point):

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -1,0 +1,354 @@
+import numpy as np
+from pyirf.binning import bin_center
+from scipy.spatial import Delaunay
+
+from .base_interpolators import DiscretePDFInterpolator
+
+__all__ = [
+    "MomentMorphInterpolator",
+]
+
+
+def estimate_mean_std(bin_edges, bin_contents):
+    """
+    Function to roughly estimate mean and standart deviation from a histogram.
+
+    Parameters
+    ----------
+    bin_edges: np.ndarray, shape=(M+1)
+        Array of common bin-edges for bin_contents
+    bin_contents: np.ndarray, shape=(N, ..., M)
+        Array of bin-entries, actual
+
+    Returns
+    -------
+    mean: np.ndarray, shape=(N, ...)
+        Estimated mean for each input template
+    std: np.ndarray, shape=(N, ...)
+        Estimated standart deviation for each input template. Set to width/2 if only one bin in
+        the input template is =/= 0
+    """
+    # Create an 2darray where the 1darray mids is repeated n_template times
+    mids = np.broadcast_to(bin_center(bin_edges), bin_contents.shape)
+    # Weighted averages to compute mean and std
+    mean = np.average(mids, weights=bin_contents, axis=-1)
+    std = np.sqrt(
+        np.average((mids - mean[..., np.newaxis]) ** 2, weights=bin_contents, axis=-1)
+    )
+
+    # Set std to 0.5*width for all those templates that have only one bin =/= 0. In those
+    # cases mids-mean = 0 and therefore std = 0. Uses the width of the one bin with
+    # bin_content!=0
+    mask = std == 0
+    if np.any(mask):
+        # Create array of bin_widths and clone for each template
+        width = np.diff(bin_edges) / 2
+        width = np.repeat(width[np.newaxis, :], bin_contents.shape[0], axis=0)
+        std[mask] = width[bin_contents[mask, :] != 0]
+
+    return mean, std
+
+
+def lookup(bin_edges, bin_contents, x):
+    """
+    Function to return the bin-height at a desired point.
+
+    Parameters
+    ----------
+    bin_edges: np.ndarray, shape=(M+1)
+        Array of common bin-edges for bin_contents
+    bin_contents: np.ndarray, shape=(N, ..., M)
+        Array of bin-entries, actual
+    x: numpy.ndarray, shape=(N, ..., M)
+        Array of M points for each input template, where the histogram-value (bin-height) should be found
+
+    Returns
+    -------
+    y: numpy.ndarray, shape=(N, ..., M)
+        Array of the bin-heights at the M points x, set to 0 at each point outside the histogram
+
+    """
+    # Create a flattend version of self.bin_contents to ease broadcasting
+    intermediate_bin_contentents = bin_contents.reshape(-1, bin_contents.shape[-1])
+
+    # Find the bin where each point x is located in
+    binnr = np.digitize(x, bin_edges).reshape(-1, bin_contents.shape[-1])
+
+    # np.digitize returns 0 if x is below the first and len(bins) if x is above the last bin,
+    # set these to 0 in a copy of the binnr to avoid errors later
+    binnr_copy = np.copy(binnr)
+    binnr_copy = np.where((binnr == 0) | (binnr == len(bin_edges)), 0, binnr_copy)
+
+    # Loop over every combination of input histograms and binning
+    lu = np.array(
+        [
+            cont[binnr]
+            for cont, binnr in zip(intermediate_bin_contentents, binnr_copy - 1)
+        ]
+    )
+
+    # Set under-/ overflowbins to 0, reshape to original shape
+    return np.where((binnr > 0) & (binnr < len(bin_edges)), lu, 0).reshape(
+        bin_contents.shape
+    )
+
+
+def baryzentric_2D_interpolation_coefficients(grid_points, target_point):
+    """
+    Compute baryzetric 2D interpolation coefficients for triangular
+    interpolation, see e.g. [1]
+
+    Parameters
+    ----------
+    grid_points: np.ndarray, shape=(3, 2)
+        Points spanning a triangle in which
+    target_point: np.ndarray, shape=(1, 2)
+        Value at which baryzentric interpolation is needed
+
+    Returns
+    -------
+    coefficients: numpy.ndarray, shape=(3,)
+        Interpolation coefficients for all three interpolation simplex vertices
+        to interpolate to the target_point
+
+    References
+    ----------
+    .. [1] https://codeplea.com/triangular-interpolation
+    """
+    # Compute distance vectors between the grid points
+    d13 = grid_points[0, :] - grid_points[2, :]
+    d23 = grid_points[1, :] - grid_points[2, :]
+
+    # Compute distance vector between target and third grid point
+    dp3 = target_point.squeeze() - grid_points[2, :]
+
+    # Compute first and second weight
+    w1 = ((d23[1] * dp3[0]) + (-d23[0] * dp3[1])) / (
+        (d23[1] * d13[0]) + (-d23[0] * d13[1])
+    )
+    w2 = ((-d13[1] * dp3[0]) + (d13[0] * dp3[1])) / (
+        (d23[1] * d13[0]) + (-d23[0] * d13[1])
+    )
+
+    # Use w1+w2+w3 = 1 for third weight
+    w3 = 1 - w1 - w2
+
+    coefficients = np.array([w1, w2, w3])
+
+    return coefficients
+
+
+def linesegment_1D_interpolation_coefficients(grid_points, target_point):
+    """
+    Compute 1D interpolation coefficients for moment morph interpolation,
+    as in eq. (6) of [1]
+
+    Parameters
+    ----------
+    grid_points: np.ndarray, shape=(2, 1)
+        Points spanning a triangle in which
+    target_point: numpy.ndarray, shape=(1, 1)
+        Value at which the histogram should be interpolated
+
+    Returns
+    -------
+    coefficients: numpy.ndarray, shape=(2,)
+        Interpolation coefficients for all three interpolation simplex vertices
+        to interpolate to the target_point
+
+    References
+    ----------
+    .. [1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between
+           multi-dimensional histograms using a new non-linear moment morphing method
+           Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033
+    """
+    # Set zeroth grid point as reference value
+    m0 = grid_points[0, :]
+
+    # Compute matrix M as in eq. (2) of [1]
+    j = np.arange(0, grid_points.shape[0], 1)
+    m_ij = (grid_points - m0) ** j
+
+    # Compute coefficients, eq. (6) from [1]
+    return np.einsum(
+        "...j, ji -> ...i", ((target_point - m0) ** j), np.linalg.inv(m_ij)
+    )
+
+
+def moment_morph_estimation(bin_edges, bin_contents, coefficients):
+    """
+    Function that wraps up the moment morph procedure [1] adopted for histograms.
+
+    Parameters
+    ----------
+    bin_edges: np.ndarray, shape=(M+1)
+        Array of common bin-edges for bin_contents
+    bin_contents: np.ndarray, shape=(N, ..., M)
+        Array of bin-entries, actual
+    coefficients: np.ndarray, shape=(N)
+        Estimation coefficients for each entry in bin_contents
+
+    Returns
+    -------
+    f_new: numpy.ndarray, shape=(1, M)
+        Interpolated histogram
+
+    References
+    ----------
+    .. [1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between
+           multi-dimensional histograms using a new non-linear moment morphing method
+           Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033
+    """
+    bin_mids = bin_center(bin_edges)
+
+    # Catch all those templates, where at least one template histogram is all zeros.
+    zero_templates = ~np.all(~np.isclose(np.sum(bin_contents, axis=-1), 0), 0)
+
+    # Manipulate those templates so that computations pass without error
+    bin_contents[:, zero_templates] = np.full(len(bin_mids), 1 / len(bin_mids))
+
+    # Estimate mean and std for each input template histogram. First adaption needed to extend
+    # the moment morph procedure to histograms
+    mus, sigs = estimate_mean_std(bin_edges=bin_edges, bin_contents=bin_contents)
+    coefficients = coefficients.reshape(
+        bin_contents.shape[0], *np.ones(mus.ndim - 1, "int")
+    )
+
+    # Transform mean and std as in eq. (11) and (12) in [1]
+    # cs = np.broadcast_to(cs, mus.shape)
+    mu_strich = np.sum(coefficients * mus, axis=0)
+    sig_strich = np.sum(coefficients * sigs, axis=0)
+
+    # Compute slope and offset as in eq. (14) and (15) in [1]
+    aij = sigs / sig_strich
+    bij = mus - mu_strich * aij
+
+    # Transformation as in eq. (13) in [1]
+    mids = np.broadcast_to(bin_mids, bin_contents.shape)
+    transf_mids = aij[..., np.newaxis] * mids + bij[..., np.newaxis]
+
+    # Compute the morphed historgram according to eq. (18) in [1]. The function "lookup" "resamples"
+    # the histogram at the transformed bin-mids by using the templates historgam value at the transformed
+    # bin-mid as new value for a whole transformed bin. Second adaption needed to extend
+    # the moment morph procedure to histograms, adaptes the behaviour of eq. (16)
+
+    transf_hist = lookup(bin_edges=bin_edges, bin_contents=bin_contents, x=transf_mids)
+
+    f_new = np.sum(
+        np.expand_dims(coefficients, -1) * transf_hist * np.expand_dims(aij, -1), axis=0
+    )
+
+    # Reset interpolation resolts for those templates with partially zero entries from above to 0
+    f_new[zero_templates] = np.zeros(len(bin_mids))
+
+    # If used normally, all values are stricktly positive, if used for extrapolation, some values can
+    # become slightly negative as the mean/std estimation is not exact.
+    f_new[f_new < 0] = 0
+
+    # Re-Normalize, needed, as the estimation of the std used above is not exact but the result is scaled with
+    # the estimated std
+    norm = np.expand_dims(np.sum(f_new, axis=-1), -1)
+
+    return np.divide(f_new, norm, out=np.zeros_like(f_new), where=norm != 0).reshape(
+        1, *bin_contents.shape[1:]
+    )
+
+
+class MomentMorphInterpolator(DiscretePDFInterpolator):
+    def __init__(self, grid_points, bin_edges, bin_contents):
+        """
+        Actual interpolator class utilizing MomentMorphInterpolations.
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(N, ...)
+            Grid points at which interpolation templates exist. May be one ot two dimensional.
+        bin_edges: np.ndarray, shape=(M+1)
+            Edges of the data binning
+        bin_content: np.ndarray, shape=(N, ..., M)
+            Content of each bin in bin_edges for
+            each point in grid_points. First dimesion has to correspond to number
+            of grid_points. Interpolation dimension, meaning the
+            the quantity that should be interpolated (e.g. the Migra axis for EDisp)
+            has to be at axis specified by axis-keyword as well as having entries
+            corresponding to the number of bins given through bin_edges keyword.
+
+        Note
+        ----
+            Also calls pyirf.interpolation.DiscretePDFInterpolator.__init__.
+        """
+        super().__init__(grid_points, bin_edges, bin_contents)
+
+        if self.grid_dim == 2:
+            self.triangulation = Delaunay(self.grid_points)
+        elif self.grid_dim > 2:
+            raise NotImplementedError(
+                "Interpolation in more then two dimension not impemented."
+            )
+
+    def _interpolate1D(self, target_point):
+        """
+        Function to find target inside 1D self.grid_points and creating a Base1DMomentMorphInterpolator
+        on this subset.
+        """
+        target_bin = np.digitize(target_point.squeeze(), self.grid_points.squeeze())
+        segment_inds = np.array([target_bin - 1, target_bin], "int")
+        coefficients = linesegment_1D_interpolation_coefficients(
+            grid_points=self.grid_points[segment_inds],
+            target_point=target_point,
+        )
+
+        return moment_morph_estimation(
+            bin_edges=self.bin_edges,
+            bin_contents=self.bin_contents[segment_inds],
+            coefficients=coefficients,
+        )
+
+    def _interpolate2D(self, target_point):
+        """
+        Function to find target inside 2D self.grid_points and creating a Base2DTriangularMomentMorphInterpolator
+        on this subset.
+        """
+        simplex_inds = self.triangulation.simplices[
+            self.triangulation.find_simplex(target_point)
+        ].squeeze()
+        coefficients = baryzentric_2D_interpolation_coefficients(
+            grid_points=self.grid_points[simplex_inds],
+            target_point=target_point,
+        )
+
+        return moment_morph_estimation(
+            bin_edges=self.bin_edges,
+            bin_contents=self.bin_contents[simplex_inds],
+            coefficients=coefficients,
+        )
+
+    def interpolate(self, target_point):
+        """
+        Takes a grid of binned pdfs for a bunch of different parameters
+        and interpolates it to given value of those parameters.
+        This function calls implementations of the moment morphing interpolation
+        pocedure introduced in [1].
+
+        Parameters
+        ----------
+        target_point: numpy.ndarray
+            Value for which the interpolation is performed (target point)
+
+        Returns
+        -------
+        f_new: numpy.ndarray, shape=(1,...,M,...)
+            Interpolated and binned pdf
+
+        References
+        ----------
+        .. [1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between
+               multi-dimensional histograms using a new non-linear moment morphing method
+               Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033
+        """
+        if self.grid_dim == 1:
+            interpolant = self._interpolate1D(target_point)
+        elif self.grid_dim == 2:
+            interpolant = self._interpolate2D(target_point)
+
+        return interpolant

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -93,6 +93,43 @@ def lookup(bin_edges, bin_contents, x):
     )
 
 
+def linesegment_1D_interpolation_coefficients(grid_points, target_point):
+    """
+    Compute 1D interpolation coefficients for moment morph interpolation,
+    as in eq. (6) of [1]
+
+    Parameters
+    ----------
+    grid_points: np.ndarray, shape=(2, 1)
+        Points spanning a triangle in which
+    target_point: numpy.ndarray, shape=(1, 1)
+        Value at which the histogram should be interpolated
+
+    Returns
+    -------
+    coefficients: numpy.ndarray, shape=(2,)
+        Interpolation coefficients for all three interpolation simplex vertices
+        to interpolate to the target_point
+
+    References
+    ----------
+    .. [1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between
+           multi-dimensional histograms using a new non-linear moment morphing method
+           Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033
+    """
+    # Set zeroth grid point as reference value
+    m0 = grid_points[0, :]
+
+    # Compute matrix M as in eq. (2) of [1]
+    j = np.arange(0, grid_points.shape[0], 1)
+    m_ij = (grid_points - m0) ** j
+
+    # Compute coefficients, eq. (6) from [1]
+    return np.einsum(
+        "...j, ji -> ...i", ((target_point - m0) ** j), np.linalg.inv(m_ij)
+    )
+
+
 def baryzentric_2D_interpolation_coefficients(grid_points, target_point):
     """
     Compute baryzetric 2D interpolation coefficients for triangular
@@ -136,43 +173,6 @@ def baryzentric_2D_interpolation_coefficients(grid_points, target_point):
     coefficients = np.array([w1, w2, w3])
 
     return coefficients
-
-
-def linesegment_1D_interpolation_coefficients(grid_points, target_point):
-    """
-    Compute 1D interpolation coefficients for moment morph interpolation,
-    as in eq. (6) of [1]
-
-    Parameters
-    ----------
-    grid_points: np.ndarray, shape=(2, 1)
-        Points spanning a triangle in which
-    target_point: numpy.ndarray, shape=(1, 1)
-        Value at which the histogram should be interpolated
-
-    Returns
-    -------
-    coefficients: numpy.ndarray, shape=(2,)
-        Interpolation coefficients for all three interpolation simplex vertices
-        to interpolate to the target_point
-
-    References
-    ----------
-    .. [1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between
-           multi-dimensional histograms using a new non-linear moment morphing method
-           Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033
-    """
-    # Set zeroth grid point as reference value
-    m0 = grid_points[0, :]
-
-    # Compute matrix M as in eq. (2) of [1]
-    j = np.arange(0, grid_points.shape[0], 1)
-    m_ij = (grid_points - m0) ** j
-
-    # Compute coefficients, eq. (6) from [1]
-    return np.einsum(
-        "...j, ji -> ...i", ((target_point - m0) ** j), np.linalg.inv(m_ij)
-    )
 
 
 def moment_morph_estimation(bin_edges, bin_contents, coefficients):

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -246,6 +246,42 @@ def test_baryzentric_2D_interpolation_coefficients():
     assert np.allclose(res, np.array([1, 1, 1]) / 3)
 
 
+def test_moment_morph_estimation1D(bins, simple_1D_data):
+    from pyirf.interpolation.moment_morph_interpolator import (
+        moment_morph_estimation,
+        linesegment_1D_interpolation_coefficients
+    )
+
+    grid, target, bin_contents, truth = simple_1D_data.values()
+
+    coeffs = linesegment_1D_interpolation_coefficients(grid, target)
+    res = moment_morph_estimation(bins, bin_contents, coeffs)
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_moment_morph_estimation1D(bins, simple_2D_data):
+    from pyirf.interpolation.moment_morph_interpolator import (
+        moment_morph_estimation,
+        baryzentric_2D_interpolation_coefficients
+    )
+
+    grid, target, bin_contents, truth = simple_2D_data.values()
+
+    coeffs = baryzentric_2D_interpolation_coefficients(grid, target)
+    res = moment_morph_estimation(bins, bin_contents, coeffs)
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
 def test_MomentMorphInterpolator1D(bins, simple_1D_data):
     from pyirf.interpolation import MomentMorphInterpolator
 

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -77,6 +77,175 @@ def simple_2D_data(bins):
     }
 
 
+def test_estimate_mean_std(bins):
+    from pyirf.interpolation.moment_morph_interpolator import estimate_mean_std
+
+    grid = np.array([[20], [40]])
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(
+                            bins
+                        )
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1, 0), scale=expected_std(x + 1, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1.5, 0),
+                            scale=expected_std(x + 1.5, 0),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 2, 0), scale=expected_std(x + 2, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    true_mean = np.array(
+        [
+            [
+                [expected_mean(x, 0), expected_mean(x + 1, 0)],
+                [expected_mean(x + 1.5, 0), expected_mean(x + 2, 0)],
+            ]
+            for x in grid
+        ]
+    ).squeeze()
+
+    true_std = np.array(
+        [
+            [
+                [expected_std(x, 0), expected_std(x + 1, 0)],
+                [expected_std(x + 1.5, 0), expected_std(x + 2, 0)],
+            ]
+            for x in grid
+        ]
+    ).squeeze()
+
+    mean, std = estimate_mean_std(bins, bin_contents)
+
+    # Assert estimation and truth within one bin
+    assert np.allclose(mean, true_mean, atol=np.diff(bins)[0] / 2)
+    assert np.allclose(std, true_std, atol=np.diff(bins)[0] / 2)
+
+
+def test_lookup():
+    from pyirf.interpolation.moment_morph_interpolator import lookup
+
+    bins = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.5])
+    bin_contents = np.array(
+        [
+            [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
+            [[6, 7, 8, 9, 10], [1, 2, 3, 4, 5]],
+        ]
+    )
+
+    x = np.array(
+        [
+            [[0.05, 0.15, 0.25, 0.35, 0.45], [0.15, 0.17, 0.21, 0.26, 0.35]],
+            [[0.25, 0.25, 0.25, 0.25, 0.25], [-0.1, 0.25, 0.25, 0.25, 0.6]],
+        ]
+    )
+
+    truth = np.array(
+        [
+            [[1, 2, 3, 4, 5], [7, 7, 8, 8, 9]],
+            [[8, 8, 8, 8, 8], [0, 3, 3, 3, 0]],  # Under/Overflow is set to 0
+        ]
+    )
+
+    assert np.allclose(lookup(bins, bin_contents, x), truth)
+
+
+def test_linesegment_1D_interpolation_coefficients():
+    from pyirf.interpolation.moment_morph_interpolator import (
+        linesegment_1D_interpolation_coefficients,
+    )
+
+    grid_points = np.array([[20], [40]])
+    target_point = np.array([[20]])
+
+    assert np.allclose(
+        linesegment_1D_interpolation_coefficients(grid_points, target_point),
+        np.array([1, 0]),
+    )
+
+    target_point = np.array([[40]])
+
+    assert np.allclose(
+        linesegment_1D_interpolation_coefficients(grid_points, target_point),
+        np.array([0, 1]),
+    )
+
+    target_point = np.array([[25]])
+
+    # Values taken from eq. (9) and (10) in Moment Morph paper Baak et al.
+    # https://doi.org/10.1016/j.nima.2014.10.033
+    mfrac = (target_point[0, 0] - grid_points[0, 0]) / (
+        grid_points[1, 0] - grid_points[0, 0]
+    )
+    cs = np.array([1 - mfrac, mfrac])
+
+    res = linesegment_1D_interpolation_coefficients(grid_points, target_point)
+
+    assert np.allclose(res, cs)
+    assert np.sum(res) == 1
+    assert np.all(np.logical_and(res < 1, res > 0))
+
+
+def test_baryzentric_2D_interpolation_coefficients():
+    from pyirf.interpolation.moment_morph_interpolator import (
+        baryzentric_2D_interpolation_coefficients,
+    )
+
+    grid_points = np.array([[20, 20], [60, 20], [40, 60]])
+    target_point = np.array([20, 20])
+
+    assert np.allclose(
+        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        np.array([1, 0, 0]),
+    )
+
+    target_point = np.array([60, 20])
+
+    assert np.allclose(
+        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        np.array([0, 1, 0]),
+    )
+
+    target_point = np.array([40, 60])
+
+    assert np.allclose(
+        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        np.array([0, 0, 1]),
+    )
+
+    target_point = np.array([40, 20])
+
+    assert np.allclose(
+        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        np.array([0.5, 0.5, 0]),
+    )
+
+    # Barycenter of triangle
+    target_point = np.array([40, 100 / 3])
+    res = baryzentric_2D_interpolation_coefficients(grid_points, target_point)
+
+    assert np.allclose(res, np.array([1, 1, 1]) / 3)
+
+
 def test_MomentMorphInterpolator1D(bins, simple_1D_data):
     from pyirf.interpolation import MomentMorphInterpolator
 
@@ -93,6 +262,25 @@ def test_MomentMorphInterpolator1D(bins, simple_1D_data):
     assert res.shape == (1, len(bins) - 1)
     # Assert truth and result matching within +- 0.1%, atol dominates comparison
     assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator1D_dirac_delta_input():
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[1], [3]])
+    bin_edges = np.array([0, 1, 2, 3, 4])
+    bin_contents = np.array(
+        [
+            [[0, 1, 0, 0], [0.25, 0.25, 0.25, 0.25]],
+            [[0, 0, 0, 1], [0.25, 0.25, 0.25, 0.25]],
+        ]
+    )
+    target = np.array([2])
+
+    interp = MomentMorphInterpolator(grid, bin_edges, bin_contents)
+    res = interp(target)
+
+    assert np.allclose(res, np.array([[0, 0, 1, 0], [0.25, 0.25, 0.25, 0.25]]))
 
 
 def test_MomentMorphInterpolator1D_all_empty(bins, simple_1D_data):
@@ -126,10 +314,8 @@ def test_MomentMorphInterpolator1D_partially_empty(bins, simple_1D_data):
     assert np.allclose(res, 0)
 
 
-def test_MomentMorphInterpolator1D_mixed_data():
+def test_MomentMorphInterpolator1D_mixed_data(bins):
     from pyirf.interpolation import MomentMorphInterpolator
-
-    bins = np.linspace(-10, 40, 1001)
 
     grid = np.array([[20], [40]])
     target = np.array([30])
@@ -225,6 +411,92 @@ def test_MomentMorphInterpolator1D_mixed_data():
     assert res.shape == (1, *bin_contents.shape[1:])
     # Assert truth and result matching within +- 0.1%, atol dominates comparison
     assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator1D_extended_grid_extradims(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20], [40], [60], [80]])
+    target = np.array([25])
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(
+                            bins
+                        )
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1, 0), scale=expected_std(x + 1, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1.5, 0),
+                            scale=expected_std(x + 1.5, 0),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 2, 0), scale=expected_std(x + 2, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    truth = np.array(
+        [
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target, 0), scale=expected_std(target, 0)
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1, 0),
+                        scale=expected_std(target + 1, 0),
+                    ).cdf(bins)
+                ),
+            ],
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1.5, 0),
+                        scale=expected_std(target + 1.5, 0),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 2, 0),
+                        scale=expected_std(target + 2, 0),
+                    ).cdf(bins)
+                ),
+            ],
+        ]
+    )
+    truth /= truth.sum(axis=-1)[..., np.newaxis]
+
+    res = interp(target)
+
+    assert np.allclose(np.sum(res, axis=-1), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, *bin_contents.shape[1:])
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-4, rtol=1e-5)
 
 
 def test_MomentMorphInterpolator2D(bins, simple_2D_data):
@@ -412,92 +684,6 @@ def test_MomentMorphInterpolator1D_extended_grid(bins):
     assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
 
 
-def test_MomentMorphInterpolator1D_extended_grid_extradims(bins):
-    from pyirf.interpolation import MomentMorphInterpolator
-
-    grid = np.array([[20], [40], [60], [80]])
-    target = np.array([25])
-    bin_contents = np.array(
-        [
-            [
-                [
-                    np.diff(
-                        norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(
-                            bins
-                        )
-                    ),
-                    np.diff(
-                        norm(
-                            loc=expected_mean(x + 1, 0), scale=expected_std(x + 1, 0)
-                        ).cdf(bins)
-                    ),
-                ],
-                [
-                    np.diff(
-                        norm(
-                            loc=expected_mean(x + 1.5, 0),
-                            scale=expected_std(x + 1.5, 0),
-                        ).cdf(bins)
-                    ),
-                    np.diff(
-                        norm(
-                            loc=expected_mean(x + 2, 0), scale=expected_std(x + 2, 0)
-                        ).cdf(bins)
-                    ),
-                ],
-            ]
-            for x in grid
-        ]
-    )
-
-    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
-
-    interp = MomentMorphInterpolator(
-        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
-    )
-
-    truth = np.array(
-        [
-            [
-                np.diff(
-                    norm(
-                        loc=expected_mean(target, 0), scale=expected_std(target, 0)
-                    ).cdf(bins)
-                ),
-                np.diff(
-                    norm(
-                        loc=expected_mean(target + 1, 0),
-                        scale=expected_std(target + 1, 0),
-                    ).cdf(bins)
-                ),
-            ],
-            [
-                np.diff(
-                    norm(
-                        loc=expected_mean(target + 1.5, 0),
-                        scale=expected_std(target + 1.5, 0),
-                    ).cdf(bins)
-                ),
-                np.diff(
-                    norm(
-                        loc=expected_mean(target + 2, 0),
-                        scale=expected_std(target + 2, 0),
-                    ).cdf(bins)
-                ),
-            ],
-        ]
-    )
-    truth /= truth.sum(axis=-1)[..., np.newaxis]
-
-    res = interp(target)
-
-    assert np.allclose(np.sum(res, axis=-1), 1)
-    assert np.all(np.isfinite(res))
-    assert res.shape == (1, *bin_contents.shape[1:])
-    # Assert truth and result matching within +- 0.1%, atol dominates comparison
-    assert np.allclose(res.squeeze(), truth, atol=1e-4, rtol=1e-5)
-
-
 def test_MomentMorphInterpolator2D_extended_grid(bins):
     from pyirf.interpolation import MomentMorphInterpolator
 
@@ -648,22 +834,3 @@ def test_MomentMorphInterpolator3D():
             bin_edges=bins,
             bin_contents=bin_contents,
         )
-
-
-def test_MomentMorphInterpolator1D_dirac_delta_input():
-    from pyirf.interpolation import MomentMorphInterpolator
-
-    grid = np.array([[1], [3]])
-    bin_edges = np.array([0, 1, 2, 3, 4])
-    bin_contents = np.array(
-        [
-            [[0, 1, 0, 0], [0.25, 0.25, 0.25, 0.25]],
-            [[0, 0, 0, 1], [0.25, 0.25, 0.25, 0.25]],
-        ]
-    )
-    target = np.array([2])
-
-    interp = MomentMorphInterpolator(grid, bin_edges, bin_contents)
-    res = interp(target)
-
-    assert np.allclose(res, np.array([[0, 0, 1, 0], [0.25, 0.25, 0.25, 0.25]]))

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -1,0 +1,669 @@
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+
+def expected_mean(a, b):
+    return 5 + (a / 5) + (b / 15)
+
+
+def expected_std(a, b):
+    return 1 + 0.05 * (a + b)
+
+
+@pytest.fixture
+def bins():
+    return np.linspace(-10, 40, 1001)
+
+
+@pytest.fixture
+def simple_1D_data(bins):
+    grid = np.array([[20], [40]])
+    target = np.array([30])
+    bin_contents = np.array(
+        [
+            np.diff(norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(bins))
+            for x in grid
+        ]
+    )
+
+    # Assert for probability outside binning
+    bin_contents /= bin_contents.sum(axis=1)[:, np.newaxis]
+
+    truth = np.diff(
+        norm(loc=expected_mean(target, 0), scale=expected_std(target, 0)).cdf(bins)
+    )
+    truth /= truth.sum()
+
+    return {
+        "grid": grid,
+        "target": target,
+        "bin_contents": bin_contents,
+        "truth": truth,
+    }
+
+
+@pytest.fixture
+def simple_2D_data(bins):
+    grid = np.array([[20, 20], [60, 20], [40, 60]])
+    target = np.array([25, 25])
+    bin_contents = np.array(
+        [
+            np.diff(
+                norm(loc=expected_mean(x[0], x[1]), scale=expected_std(x[0], x[1])).cdf(
+                    bins
+                )
+            )
+            for x in grid
+        ]
+    )
+
+    # Assert for probability outside binning
+    bin_contents /= bin_contents.sum(axis=1)[:, np.newaxis]
+
+    truth = np.diff(
+        norm(
+            loc=expected_mean(target[0], target[1]),
+            scale=expected_std(target[0], target[1]),
+        ).cdf(bins)
+    )
+    truth /= truth.sum()
+
+    return {
+        "grid": grid,
+        "target": target,
+        "bin_contents": bin_contents,
+        "truth": truth,
+    }
+
+
+def test_MomentMorphInterpolator1D(bins, simple_1D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, bin_contents, truth = simple_1D_data.values()
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator1D_all_empty(bins, simple_1D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, _, _ = simple_1D_data.values()
+    bin_contents = np.array([np.zeros(len(bins) - 1) for _ in grid])
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.allclose(res, 0)
+
+
+def test_MomentMorphInterpolator1D_partially_empty(bins, simple_1D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, bin_contents, _ = simple_1D_data.values()
+
+    bin_contents[0, :] = np.zeros(len(bins) - 1)
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.allclose(res, 0)
+
+
+def test_MomentMorphInterpolator1D_mixed_data():
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    bins = np.linspace(-10, 40, 1001)
+
+    grid = np.array([[20], [40]])
+    target = np.array([30])
+
+    # Create template histograms
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(
+                            bins
+                        )
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1, 0), scale=expected_std(x + 1, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1.5, 0),
+                            scale=expected_std(x + 1.5, 0),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 2, 0), scale=expected_std(x + 2, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
+
+    # Make template histograms at indizes [:, 1, 1, :] all zeroed
+    bin_contents[:, 1, 1, :] = np.zeros(len(bins) - 1)
+
+    # Zero template histogram at index [1, 0, 0, :]
+    bin_contents[1, 0, 0, :] = np.zeros(len(bins) - 1)
+
+    truth = np.array(
+        [
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target, 0), scale=expected_std(target, 0)
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1, 0),
+                        scale=expected_std(target + 1, 0),
+                    ).cdf(bins)
+                ),
+            ],
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1.5, 0),
+                        scale=expected_std(target + 1.5, 0),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 2, 0),
+                        scale=expected_std(target + 2, 0),
+                    ).cdf(bins)
+                ),
+            ],
+        ]
+    )
+    truth /= truth.sum(axis=-1)[..., np.newaxis]
+
+    # Expect zeros for at least partially zeroed input templates
+    truth[0, 0, :] = np.zeros(len(bins) - 1)
+    truth[1, 1, :] = np.zeros(len(bins) - 1)
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    expected_norms = np.array([[0, 1], [1, 0]])
+    assert np.allclose(np.sum(res, axis=-1), expected_norms)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, *bin_contents.shape[1:])
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator2D(bins, simple_2D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, bin_contents, truth = simple_2D_data.values()
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator2D_partially_empty(bins, simple_2D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, bin_contents, _ = simple_2D_data.values()
+
+    bin_contents[0, :] = np.zeros(len(bins) - 1)
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.allclose(res, 0)
+
+
+def test_MomentMorphInterpolator2D_all_empty(bins, simple_2D_data):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid, target, _, _ = simple_2D_data.values()
+    bin_contents = np.array([np.zeros(len(bins) - 1) for _ in grid])
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    assert np.allclose(res, 0)
+
+
+def test_MomentMorphInterpolator2D_mixed(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20, 20], [60, 20], [40, 60]])
+    target = np.array([25, 25])
+
+    # Create template histograms
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0], x[1]),
+                            scale=expected_std(x[0], x[1]),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 1, x[1]),
+                            scale=expected_std(x[0] + 1, x[1]),
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 1.5, x[1]),
+                            scale=expected_std(x[0] + 1.5, x[1]),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 2, x[1]),
+                            scale=expected_std(x[0] + 2, x[1]),
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
+
+    # Make template histograms at indizes [:, 1, 1, :] all zeroed
+    bin_contents[:, 1, 1, :] = np.zeros(len(bins) - 1)
+
+    # Zero template histogram at index [1, 0, 0, :]
+    bin_contents[1, 0, 0, :] = np.zeros(len(bins) - 1)
+
+    truth = np.array(
+        [
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0], target[1]),
+                        scale=expected_std(target[0], target[1]),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 1, target[1]),
+                        scale=expected_std(target[0] + 1, target[1]),
+                    ).cdf(bins)
+                ),
+            ],
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 1.5, target[1]),
+                        scale=expected_std(target[0] + 1.5, target[1]),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 2, target[1]),
+                        scale=expected_std(target[0] + 2, target[1]),
+                    ).cdf(bins)
+                ),
+            ],
+        ]
+    )
+    truth /= truth.sum(axis=-1)[..., np.newaxis]
+
+    # Expect zeros for at least partially zeroed input templates
+    truth[0, 0, :] = np.zeros(len(bins) - 1)
+    truth[1, 1, :] = np.zeros(len(bins) - 1)
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    res = interp(target)
+
+    expected_norms = np.array([[0, 1], [1, 0]])
+    assert np.allclose(np.sum(res, axis=-1), expected_norms)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, *bin_contents.shape[1:])
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator1D_extended_grid(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20], [40], [60], [80]])
+    target = np.array([25])
+    bin_contents = np.array(
+        [
+            np.diff(norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(bins))
+            for x in grid
+        ]
+    )
+    # Assert for probability outside binning
+    bin_contents /= bin_contents.sum(axis=1)[:, np.newaxis]
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid,
+        bin_edges=bins,
+        bin_contents=bin_contents,
+    )
+
+    res = interp(target)
+    truth = np.diff(
+        norm(loc=expected_mean(target, 0), scale=expected_std(target, 0)).cdf(bins)
+    )
+    truth /= truth.sum()
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator1D_extended_grid_extradims(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20], [40], [60], [80]])
+    target = np.array([25])
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(loc=expected_mean(x, 0), scale=expected_std(x, 0)).cdf(
+                            bins
+                        )
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1, 0), scale=expected_std(x + 1, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 1.5, 0),
+                            scale=expected_std(x + 1.5, 0),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x + 2, 0), scale=expected_std(x + 2, 0)
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid, bin_edges=bins, bin_contents=bin_contents
+    )
+
+    truth = np.array(
+        [
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target, 0), scale=expected_std(target, 0)
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1, 0),
+                        scale=expected_std(target + 1, 0),
+                    ).cdf(bins)
+                ),
+            ],
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 1.5, 0),
+                        scale=expected_std(target + 1.5, 0),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target + 2, 0),
+                        scale=expected_std(target + 2, 0),
+                    ).cdf(bins)
+                ),
+            ],
+        ]
+    )
+    truth /= truth.sum(axis=-1)[..., np.newaxis]
+
+    res = interp(target)
+
+    assert np.allclose(np.sum(res, axis=-1), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, *bin_contents.shape[1:])
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-4, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator2D_extended_grid(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20, 20], [40, 20], [30, 40], [50, 20], [45, 40]])
+    target = np.array([25, 25])
+    bin_contents = np.array(
+        [
+            np.diff(
+                norm(loc=expected_mean(x[0], x[1]), scale=expected_std(x[0], x[1])).cdf(
+                    bins
+                )
+            )
+            for x in grid
+        ]
+    )
+    # Assert for probability outside binning
+    bin_contents /= bin_contents.sum(axis=1)[:, np.newaxis]
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid,
+        bin_edges=bins,
+        bin_contents=bin_contents,
+    )
+
+    res = interp(target)
+    truth = np.diff(
+        norm(
+            loc=expected_mean(target[0], target[1]),
+            scale=expected_std(target[0], target[1]),
+        ).cdf(bins)
+    )
+    truth /= truth.sum()
+
+    assert np.isclose(np.sum(res), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, len(bins) - 1)
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator2D_extended_grid_extradims(bins):
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[20, 20], [40, 20], [30, 40], [50, 20], [45, 40]])
+    target = np.array([25, 25])
+    bin_contents = np.array(
+        [
+            [
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0], x[1]),
+                            scale=expected_std(x[0], x[1]),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 1, x[1]),
+                            scale=expected_std(x[0] + 1, x[1]),
+                        ).cdf(bins)
+                    ),
+                ],
+                [
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 1.5, x[1]),
+                            scale=expected_std(x[0] + 1.5, x[1]),
+                        ).cdf(bins)
+                    ),
+                    np.diff(
+                        norm(
+                            loc=expected_mean(x[0] + 2, x[1]),
+                            scale=expected_std(x[0] + 2, x[1]),
+                        ).cdf(bins)
+                    ),
+                ],
+            ]
+            for x in grid
+        ]
+    )
+
+    bin_contents /= bin_contents.sum(axis=-1)[..., np.newaxis]
+
+    interp = MomentMorphInterpolator(
+        grid_points=grid,
+        bin_edges=bins,
+        bin_contents=bin_contents,
+    )
+
+    truth = np.array(
+        [
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0], target[1]),
+                        scale=expected_std(target[0], target[1]),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 1, target[1]),
+                        scale=expected_std(target[0] + 1, target[1]),
+                    ).cdf(bins)
+                ),
+            ],
+            [
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 1.5, target[1]),
+                        scale=expected_std(target[0] + 1.5, target[1]),
+                    ).cdf(bins)
+                ),
+                np.diff(
+                    norm(
+                        loc=expected_mean(target[0] + 2, target[1]),
+                        scale=expected_std(target[0] + 2, target[1]),
+                    ).cdf(bins)
+                ),
+            ],
+        ]
+    )
+    truth /= truth.sum(axis=-1)[..., np.newaxis]
+
+    res = interp(target)
+
+    assert np.allclose(np.sum(res, axis=-1), 1)
+    assert np.all(np.isfinite(res))
+    assert res.shape == (1, *bin_contents.shape[1:])
+    # Assert truth and result matching within +- 0.1%, atol dominates comparison
+    assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
+
+
+def test_MomentMorphInterpolator3D():
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    bins = np.linspace(0, 1, 11)
+
+    grid = np.array([[0, 0, 0], [0, 20, 0], [20, 0, 0], [20, 20, 0], [10, 10, 10]])
+
+    bin_contents = np.array([np.ones(len(bins) - 1) / (len(bins) - 1) for _ in grid])
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Interpolation in more then two dimension not impemented.",
+    ):
+        MomentMorphInterpolator(
+            grid_points=grid,
+            bin_edges=bins,
+            bin_contents=bin_contents,
+        )
+
+
+def test_MomentMorphInterpolator1D_dirac_delta_input():
+    from pyirf.interpolation import MomentMorphInterpolator
+
+    grid = np.array([[1], [3]])
+    bin_edges = np.array([0, 1, 2, 3, 4])
+    bin_contents = np.array(
+        [
+            [[0, 1, 0, 0], [0.25, 0.25, 0.25, 0.25]],
+            [[0, 0, 0, 1], [0.25, 0.25, 0.25, 0.25]],
+        ]
+    )
+    target = np.array([2])
+
+    interp = MomentMorphInterpolator(grid, bin_edges, bin_contents)
+    res = interp(target)
+
+    assert np.allclose(res, np.array([[0, 0, 1, 0], [0.25, 0.25, 0.25, 0.25]]))

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -78,7 +78,7 @@ def simple_2D_data(bins):
 
 
 def test_estimate_mean_std(bins):
-    from pyirf.interpolation.moment_morph_interpolator import estimate_mean_std
+    from pyirf.interpolation.moment_morph_interpolator import _estimate_mean_std
 
     grid = np.array([[20], [40]])
     bin_contents = np.array(
@@ -134,7 +134,7 @@ def test_estimate_mean_std(bins):
         ]
     ).squeeze()
 
-    mean, std = estimate_mean_std(bins, bin_contents)
+    mean, std = _estimate_mean_std(bins, bin_contents)
 
     # Assert estimation and truth within one bin
     assert np.allclose(mean, true_mean, atol=np.diff(bins)[0] / 2)
@@ -142,7 +142,7 @@ def test_estimate_mean_std(bins):
 
 
 def test_lookup():
-    from pyirf.interpolation.moment_morph_interpolator import lookup
+    from pyirf.interpolation.moment_morph_interpolator import _lookup
 
     bins = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.5])
     bin_contents = np.array(
@@ -166,7 +166,7 @@ def test_lookup():
         ]
     )
 
-    assert np.allclose(lookup(bins, bin_contents, x), truth)
+    assert np.allclose(_lookup(bins, bin_contents, x), truth)
 
 
 def test_linesegment_1D_interpolation_coefficients():

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -248,8 +248,8 @@ def test_baryzentric_2D_interpolation_coefficients():
 
 def test_moment_morph_estimation1D(bins, simple_1D_data):
     from pyirf.interpolation.moment_morph_interpolator import (
+        linesegment_1D_interpolation_coefficients,
         moment_morph_estimation,
-        linesegment_1D_interpolation_coefficients
     )
 
     grid, target, bin_contents, truth = simple_1D_data.values()
@@ -266,8 +266,8 @@ def test_moment_morph_estimation1D(bins, simple_1D_data):
 
 def test_moment_morph_estimation1D(bins, simple_2D_data):
     from pyirf.interpolation.moment_morph_interpolator import (
+        baryzentric_2D_interpolation_coefficients,
         moment_morph_estimation,
-        baryzentric_2D_interpolation_coefficients
     )
 
     grid, target, bin_contents, truth = simple_2D_data.values()

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -264,7 +264,7 @@ def test_moment_morph_estimation1D(bins, simple_1D_data):
     assert np.allclose(res.squeeze(), truth, atol=1e-3, rtol=1e-5)
 
 
-def test_moment_morph_estimation1D(bins, simple_2D_data):
+def test_moment_morph_estimation2D(bins, simple_2D_data):
     from pyirf.interpolation.moment_morph_interpolator import (
         baryzentric_2D_interpolation_coefficients,
         moment_morph_estimation,


### PR DESCRIPTION
_This is a new version of #221 that gets rid of most classes. It thus supersedes #221. @maxnoe's comments in #221 were included in this version_

This PR introduces another interpolation method (Moment Morphing, see [1]). While performing comparably to the already existing Quantile Interpolation the main points in favor of this method is that it can be can be separated into two steps. First, one has to compute interpolation coefficients and then these are used to morph and interpolate the input pdfs. When changing the coefficients (e.g. changing interpolation to extrapolation or changing from interpolation in a triangle to interpolation in a rectangle) the second part remains unchanged. Consequently, using this for extrapolation is quite simple.

This PR is quite extensive in its additions. Most of these are actually tests, checking all kind of broadcasting and border cases.

[1] M. Baak, S. Gadatsch, R. Harrington and W. Verkerke (2015). Interpolation between multi-dimensional histograms using a new non-linear moment morphing method. Nucl. Instrum. Methods Phys. Res. A 771, 39-48. https://doi.org/10.1016/j.nima.2014.10.033