### PR TITLE
Add Nearest Neighbor Searcher as Alternative for Inter-/Extrapolation

### DIFF
--- a/docs/changes/232.feature.rst
+++ b/docs/changes/232.feature.rst
@@ -1,1 +1,2 @@
-This PR adds a NearestNeighborSearcher for inter-/ and extrapolation
+This PR adds a DiscretePDFNearestNeighborSearcher and a ParametrizedNearestNeighborSeacher to support nearest neighbor approaches 
+as alternatives to inter-/ and extrapolation

--- a/docs/changes/232.feature.rst
+++ b/docs/changes/232.feature.rst
@@ -1,0 +1,1 @@
+This PR adds a NearestNeighborSearcher for inter-/ and extrapolation

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -18,6 +18,7 @@ from .component_estimators import (
 )
 from .griddata_interpolator import GridDataInterpolator
 from .moment_morph_interpolator import MomentMorphInterpolator
+from .nearest_neighbor_searcher import NearestNeighborSearcher
 from .quantile_interpolator import QuantileInterpolator
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "RadMaxEstimator",
     "EnergyDispersionEstimator",
     "PSFTableEstimator",
+    "NearestNeighborSearcher",
 ]

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -18,22 +18,28 @@ from .component_estimators import (
 )
 from .griddata_interpolator import GridDataInterpolator
 from .moment_morph_interpolator import MomentMorphInterpolator
-from .nearest_neighbor_searcher import NearestNeighborSearcher
+from .nearest_neighbor_searcher import (
+    BaseNearestNeighborSearcher,
+    DiscretePDFNearestNeighborSearcher,
+    ParametrizedNearestNeighborSearcher,
+)
 from .quantile_interpolator import QuantileInterpolator
 
 __all__ = [
     "BaseComponentEstimator",
     "BaseInterpolator",
+    "BaseNearestNeighborSearcher",
     "DiscretePDFComponentEstimator",
     "DiscretePDFInterpolator",
+    "DiscretePDFNearestNeighborSearcher",
     "GridDataInterpolator",
     "MomentMorphInterpolator",
     "ParametrizedComponentEstimator",
     "ParametrizedInterpolator",
+    "ParametrizedNearestNeighborSearcher",
     "QuantileInterpolator",
     "EffectiveAreaEstimator",
     "RadMaxEstimator",
     "EnergyDispersionEstimator",
     "PSFTableEstimator",
-    "NearestNeighborSearcher",
 ]

--- a/pyirf/interpolation/base_interpolators.py
+++ b/pyirf/interpolation/base_interpolators.py
@@ -2,6 +2,7 @@
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
+import pyirf.interpolation as pyint
 from pyirf.binning import bin_center
 
 __all__ = ["BaseInterpolator", "ParametrizedInterpolator", "DiscretePDFInterpolator"]
@@ -14,7 +15,7 @@ class BaseInterpolator(metaclass=ABCMeta):
     """
 
     def __init__(self, grid_points):
-        """BaseInterpolator  
+        """BaseInterpolator
 
         Parameters
         ----------
@@ -77,6 +78,13 @@ class ParametrizedInterpolator(BaseInterpolator):
         if self.params.ndim == 1:
             self.params = self.params[..., np.newaxis]
 
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if subclass is pyint.ParametrizedNearestNeighborSearcher:
+            return True
+        else:
+            return NotImplemented
+
 
 class DiscretePDFInterpolator(BaseInterpolator):
     """
@@ -109,3 +117,10 @@ class DiscretePDFInterpolator(BaseInterpolator):
         self.bin_edges = bin_edges
         self.bin_mids = bin_center(self.bin_edges)
         self.bin_contents = bin_contents
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if subclass is pyint.DiscretePDFNearestNeighborSearcher:
+            return True
+        else:
+            return NotImplemented

--- a/pyirf/interpolation/base_interpolators.py
+++ b/pyirf/interpolation/base_interpolators.py
@@ -2,7 +2,6 @@
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-import pyirf.interpolation as pyint
 from pyirf.binning import bin_center
 
 __all__ = ["BaseInterpolator", "ParametrizedInterpolator", "DiscretePDFInterpolator"]
@@ -78,13 +77,6 @@ class ParametrizedInterpolator(BaseInterpolator):
         if self.params.ndim == 1:
             self.params = self.params[..., np.newaxis]
 
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        if subclass is pyint.ParametrizedNearestNeighborSearcher:
-            return True
-        else:
-            return NotImplemented
-
 
 class DiscretePDFInterpolator(BaseInterpolator):
     """
@@ -117,10 +109,3 @@ class DiscretePDFInterpolator(BaseInterpolator):
         self.bin_edges = bin_edges
         self.bin_mids = bin_center(self.bin_edges)
         self.bin_contents = bin_contents
-
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        if subclass is pyint.DiscretePDFNearestNeighborSearcher:
-            return True
-        else:
-            return NotImplemented

--- a/pyirf/interpolation/component_estimators.py
+++ b/pyirf/interpolation/component_estimators.py
@@ -43,7 +43,6 @@ class BaseComponentEstimator:
         Parameters
         ----------
         grid_points: np.ndarray, shape=(n_points, n_dims):
-            Grid points at which interpolation templates exist
 
         Raises
         ------
@@ -199,8 +198,7 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         TypeError:
             When bin_content is not a np.ndarray
         TypeError:
-            When interpolator_cls is not a DiscretePDFInterpolator subclass or
-            DiscretePDFNearestNeighborSeacher.
+            When interpolator_cls is not a DiscretePDFInterpolator subclass.
         ValueError:
             When number of bins in bin_edges and contents in bin_contents is
             not matching.
@@ -239,13 +237,9 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         if extrapolator_kwargs is None:
             extrapolator_kwargs = {}
 
-        if not (
-            issubclass(interpolator_cls, DiscretePDFInterpolator)
-            or issubclass(interpolator_cls, DiscretePDFNearestNeighborSearcher)
-        ):
+        if not issubclass(interpolator_cls, DiscretePDFInterpolator):
             raise TypeError(
-                "interpolator_cls must be a DiscretePDFInterpolator subclass or "
-                f"DiscretePDFNearestNeighborSearcher, got {interpolator_cls}"
+                f"interpolator_cls must be a DiscretePDFInterpolator subclass, got {interpolator_cls}"
             )
 
         self.interpolator = interpolator_cls(
@@ -305,8 +299,7 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
         Raises
         ------
         TypeError:
-            When interpolator_cls is not a ParametrizedInterpolator subclass
-            or ParametrizedNearestNeighborSearcher.
+            When interpolator_cls is not a ParametrizedInterpolator subclass.
         TypeError:
             When params is not a np.ndarray
         ValueError:
@@ -334,13 +327,9 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
         if extrapolator_kwargs is None:
             extrapolator_kwargs = {}
 
-        if not (
-            issubclass(interpolator_cls, ParametrizedInterpolator)
-            or issubclass(interpolator_cls, ParametrizedNearestNeighborSearcher)
-        ):
+        if not issubclass(interpolator_cls, ParametrizedInterpolator):
             raise TypeError(
-                "interpolator_cls must be a ParametrizedInterpolator subclass or "
-                f"ParametrizedNearestNeighborSearcher, got {interpolator_cls}"
+                f"interpolator_cls must be a ParametrizedInterpolator subclass, got {interpolator_cls}"
             )
 
         self.interpolator = interpolator_cls(grid_points, params, **interpolator_kwargs)

--- a/pyirf/interpolation/component_estimators.py
+++ b/pyirf/interpolation/component_estimators.py
@@ -8,6 +8,7 @@ from pyirf.interpolation.base_interpolators import (
     ParametrizedInterpolator,
 )
 from pyirf.interpolation.griddata_interpolator import GridDataInterpolator
+from pyirf.interpolation.nearest_neighbor_searcher import NearestNeighborSearcher
 from pyirf.interpolation.quantile_interpolator import QuantileInterpolator
 from pyirf.utils import cone_solid_angle
 from scipy.spatial import Delaunay
@@ -169,7 +170,10 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         grid_points: np.ndarray, shape=(n_points, n_dims):
             Grid points at which interpolation templates exist
         bin_edges: np.ndarray, shape=(n_bins+1)
-            Common set of bin-edges for all discretized PDFs
+            Common set of bin-edges for all discretized PDFs. Ignored if
+            interpolator_cls is NearestNeighborSearcher and, at the same time,
+            extrapolator_cls is None or NearestNeighborSearcher.
+            Can thus be e.g. None in these cases.
         bin_contents: np.ndarray, shape=(n_points, ..., n_bins)
             Discretized PDFs for all grid points and arbitrary further dimensions
             (in IRF term e.g. field-of-view offset bins). Actual interpolation dimension,
@@ -191,14 +195,15 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         Raises
         ------
         TypeError:
-            When bin_edges is not a np.ndarray
+            When bin_edges is not a np.ndarray and not ignored.
         TypeError:
             When bin_content is not a np.ndarray
         TypeError:
-            When interpolator_cls is not a BinnedInterpolator subclass.
+            When interpolator_cls is not a BinnedInterpolator subclass or
+            NearestNeighborSeacher.
         ValueError:
             When number of bins in bin_edges and contents bin_contents is
-            not matching
+            not matching and bin_edges is not ignored.
         ValueError:
             When number of histograms in bin_contents and points in grid_points
             is not matching
@@ -212,21 +217,34 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
             grid_points,
         )
 
-        if not isinstance(bin_edges, np.ndarray):
-            raise TypeError("Input bin_edges is not a numpy array.")
-        elif not isinstance(bin_contents, np.ndarray):
+        # Ignore bin_edges if both inter- and extrapolator are NearestNeighborSeacher
+        # or None (for the extrapolator)
+        if issubclass(interpolator_cls, NearestNeighborSearcher):
+            if extrapolator_cls is None:
+                ignore_edges = True
+            elif issubclass(extrapolator_cls, NearestNeighborSearcher):
+                ignore_edges = True
+            else:
+                ignore_edges = False
+        else:
+            ignore_edges = False
+
+        if not isinstance(bin_contents, np.ndarray):
             raise TypeError("Input bin_contents is not a numpy array.")
-        elif bin_contents.shape[-1] != (bin_edges.shape[0] - 1):
-            raise ValueError(
-                f"Shape missmatch, bin_edges ({bin_edges.shape[0] - 1} bins) "
-                f"and bin_contents ({bin_contents.shape[-1]} bins) not matching."
-            )
         elif self.n_points != bin_contents.shape[0]:
             raise ValueError(
                 f"Shape missmatch, number of grid_points ({self.n_points}) and "
                 f"number of histograms in bin_contents ({bin_contents.shape[0]}) "
                 "not matching."
             )
+        if not ignore_edges:
+            if not isinstance(bin_edges, np.ndarray):
+                raise TypeError("Input bin_edges is not a numpy array.")
+            elif bin_contents.shape[-1] != (bin_edges.shape[0] - 1):
+                raise ValueError(
+                    f"Shape missmatch, bin_edges ({bin_edges.shape[0] - 1} bins) "
+                    f"and bin_contents ({bin_contents.shape[-1]} bins) not matching."
+                )
 
         if interpolator_kwargs is None:
             interpolator_kwargs = {}
@@ -234,17 +252,26 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         if extrapolator_kwargs is None:
             extrapolator_kwargs = {}
 
-        if not issubclass(interpolator_cls, DiscretePDFInterpolator):
-            raise TypeError(
-                f"interpolator_cls must be a DiscretePDFInterpolator subclass, got {interpolator_cls}"
+        if issubclass(interpolator_cls, DiscretePDFInterpolator):
+            self.interpolator = interpolator_cls(
+                grid_points, bin_edges, bin_contents, **interpolator_kwargs
             )
-
-        self.interpolator = interpolator_cls(
-            grid_points, bin_edges, bin_contents, **interpolator_kwargs
-        )
+        elif issubclass(interpolator_cls, NearestNeighborSearcher):
+            self.interpolator = interpolator_cls(
+                grid_points, bin_contents, **interpolator_kwargs
+            )
+        else:
+            raise TypeError(
+                "interpolator_cls must be a DiscretePDFInterpolator subclass or "
+                f"NearestNeighborSearcher, got {interpolator_cls}"
+            )
 
         if extrapolator_cls is None:
             self.extrapolator = None
+        elif issubclass(extrapolator_cls, NearestNeighborSearcher):
+            self.extrapolator = extrapolator_cls(
+                grid_points, bin_contents, **extrapolator_kwargs
+            )
         else:
             self.extrapolator = extrapolator_cls(
                 grid_points, bin_edges, bin_contents, **extrapolator_kwargs
@@ -296,7 +323,8 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
         Raises
         ------
         TypeError:
-            When interpolator_cls is not a ParametrizedInterpolator subclass.
+            When interpolator_cls is not a ParametrizedInterpolator subclass
+            or NearestNeighborSearcher.
         TypeError:
             When params is not a np.ndarray
         ValueError:
@@ -324,9 +352,13 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
         if extrapolator_kwargs is None:
             extrapolator_kwargs = {}
 
-        if not issubclass(interpolator_cls, ParametrizedInterpolator):
+        if not (
+            issubclass(interpolator_cls, ParametrizedInterpolator)
+            or issubclass(interpolator_cls, NearestNeighborSearcher)
+        ):
             raise TypeError(
-                f"interpolator_cls must be a ParametrizedInterpolator subclass, got {interpolator_cls}"
+                "interpolator_cls must be a ParametrizedInterpolator subclass or "
+                f"NearestNeighborSearcher, got {interpolator_cls}"
             )
 
         self.interpolator = interpolator_cls(grid_points, params, **interpolator_kwargs)

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -1,5 +1,10 @@
 import numpy as np
-from .base_interpolators import BaseInterpolator
+
+from .base_interpolators import (
+    BaseInterpolator,
+    DiscretePDFInterpolator,
+    ParametrizedInterpolator,
+)
 
 __all__ = [
     "BaseNearestNeighborSearcher",
@@ -130,6 +135,9 @@ class DiscretePDFNearestNeighborSearcher(BaseNearestNeighborSearcher):
         )
 
 
+DiscretePDFInterpolator.register(DiscretePDFNearestNeighborSearcher)
+
+
 class ParametrizedNearestNeighborSearcher(BaseNearestNeighborSearcher):
     """
     Dummy NearestNeighbor approach usable instead of
@@ -159,3 +167,6 @@ class ParametrizedNearestNeighborSearcher(BaseNearestNeighborSearcher):
         """
 
         super().__init__(grid_points=grid_points, contents=params, norm_ord=norm_ord)
+
+
+ParametrizedInterpolator.register(ParametrizedNearestNeighborSearcher)

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from .base_interpolators import BaseInterpolator
 
 __all__ = [

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from .base_interpolators import BaseInterpolator
+
+__all__ = ["NearestNeighborSearcher"]
+
+
+class NearestNeighborSearcher(BaseInterpolator):
+    """
+    Dummy NearestNeighbor approach usable instead of
+    actual Interpolation/Extrapolation
+    """
+
+    def __init__(self, grid_points, contents, norm_ord=2):
+        """
+        NearestNeighborSearcher
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(n_points, n_dims)
+            Grid points at which templates exist
+        contents: np.ndarray, shape=(n_points, ...)
+            Corresponding IRF contents at grid_points
+        norm_ord: non-zero int
+            Order of the norm which is used to compute the distances,
+            passed to numpy.linalg.norm [1]. Defaults to 2,
+            which uses the euclidean norm.
+
+        Note
+        ----
+            Also calls pyirf.interpolation.BaseInterpolators.__init__
+        """
+
+        super().__init__(grid_points)
+
+        self.contents = contents
+
+        # Test wether norm_ord is a number
+        try:
+            norm_ord > 0
+        except TypeError:
+            raise ValueError(
+                f"Only positiv integers allowed for norm_ord, got {norm_ord}."
+            )
+
+        # Test wether norm_ord is a finite, positive integer
+        if (norm_ord <= 0) or ~np.isfinite(norm_ord) or (norm_ord != int(norm_ord)):
+            raise ValueError(
+                f"Only positiv integers allowed for norm_ord, got {norm_ord}."
+            )
+
+        self.norm_ord = norm_ord
+
+    def interpolate(self, target_point):
+        """
+        Takes a grid of IRF contents for a bunch of different parameters
+        and returns the contents at the nearest grid point
+        as seen from the target point.
+
+        Parameters
+        ----------
+        target_point: numpy.ndarray
+            Value for which the nearest neighbor should be found (target point)
+
+        Returns
+        -------
+        content_new: numpy.ndarray, shape=(1,...,M,...)
+            Contents at nearest neighbor
+
+        Note
+        ----
+            In case of multiple nearest neighbors, the contents corresponding
+            to the first one are returned.
+        """
+
+        if target_point.ndim == 1:
+            target_point = target_point.reshape(1, *target_point.shape)
+
+        distances = np.linalg.norm(
+            self.grid_points - target_point, ord=self.norm_ord, axis=1
+        )
+
+        index = np.argmin(distances)
+
+        return self.contents[index, :]

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -26,6 +26,11 @@ class NearestNeighborSearcher(BaseInterpolator):
             passed to numpy.linalg.norm [1]. Defaults to 2,
             which uses the euclidean norm.
 
+        Raises
+        ------
+        TypeError:
+            If norm_ord is not non-zero integer
+
         Note
         ----
             Also calls pyirf.interpolation.BaseInterpolators.__init__

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -2,10 +2,14 @@ import numpy as np
 
 from .base_interpolators import BaseInterpolator
 
-__all__ = ["NearestNeighborSearcher"]
+__all__ = [
+    "BaseNearestNeighborSearcher",
+    "DiscretePDFNearestNeighborSearcher",
+    "ParametrizedNearestNeighborSearcher",
+]
 
 
-class NearestNeighborSearcher(BaseInterpolator):
+class BaseNearestNeighborSearcher(BaseInterpolator):
     """
     Dummy NearestNeighbor approach usable instead of
     actual Interpolation/Extrapolation
@@ -13,7 +17,7 @@ class NearestNeighborSearcher(BaseInterpolator):
 
     def __init__(self, grid_points, contents, norm_ord=2):
         """
-        NearestNeighborSearcher
+        BaseNearestNeighborSearcher
 
         Parameters
         ----------
@@ -88,3 +92,71 @@ class NearestNeighborSearcher(BaseInterpolator):
         index = np.argmin(distances)
 
         return self.contents[index, :]
+
+
+class DiscretePDFNearestNeighborSearcher(BaseNearestNeighborSearcher):
+    """
+    Dummy NearestNeighbor approach usable instead of
+    actual Interpolation/Extrapolation.
+    Compatible with discretized PDF IRF component API.
+    """
+
+    def __init__(self, grid_points, bin_edges, bin_contents, norm_ord=2):
+        """
+        NearestNeighborSearcher compatible with discretized PDF IRF components API
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(n_points, n_dims)
+            Grid points at which templates exist
+        bin_edges: np.ndarray, shape=(n_bins+1)
+            Edges of the data binning. Ignored for nearest neighbor searching.
+        bin_content: np.ndarray, shape=(n_points, ..., n_bins)
+            Content of each bin in bin_edges for
+            each point in grid_points. First dimesion has to correspond to number
+            of grid_points, last dimension has to correspond to number of bins for
+            the quantity that should be interpolated (e.g. the Migra axis for EDisp)
+        norm_ord: non-zero int
+            Order of the norm which is used to compute the distances,
+            passed to numpy.linalg.norm [1]. Defaults to 2,
+            which uses the euclidean norm.
+
+        Note
+        ----
+            Also calls pyirf.interpolation.BaseNearestNeighborSearcher.__init__
+        """
+
+        super().__init__(
+            grid_points=grid_points, contents=bin_contents, norm_ord=norm_ord
+        )
+
+
+class ParametrizedNearestNeighborSearcher(BaseNearestNeighborSearcher):
+    """
+    Dummy NearestNeighbor approach usable instead of
+    actual Interpolation/Extrapolation
+    Compatible with parametrized IRF component API.
+    """
+
+    def __init__(self, grid_points, params, norm_ord=2):
+        """
+        NearestNeighborSearcher compatible with parametrized IRF components API
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(n_points, n_dims)
+            Grid points at which templates exist
+        params: np.ndarray, shape=(n_points, ..., n_params)
+            Corresponding parameter values at each point in grid_points.
+            First dimesion has to correspond to number of grid_points
+        norm_ord: non-zero int
+            Order of the norm which is used to compute the distances,
+            passed to numpy.linalg.norm [1]. Defaults to 2,
+            which uses the euclidean norm.
+
+        Note
+        ----
+            Also calls pyirf.interpolation.BaseNearestNeighborSearcher.__init__
+        """
+
+        super().__init__(grid_points=grid_points, contents=params, norm_ord=norm_ord)

--- a/pyirf/interpolation/tests/test_base_interpolators.py
+++ b/pyirf/interpolation/tests/test_base_interpolators.py
@@ -76,3 +76,18 @@ def test_DiscretePDFInterpolator_instantiation():
 
     interp2D = DummyBinnedInterpolator(grid_points2D, bin_edges, bin_content)
     assert interp2D(target2D) == 42
+
+
+def test_virtual_subclasses():
+    """Tests that corresponding nearest neighbor seacher are virtual sublasses of interpolators"""
+    from pyirf.interpolation import (
+        DiscretePDFInterpolator,
+        DiscretePDFNearestNeighborSearcher,
+        ParametrizedInterpolator,
+        ParametrizedNearestNeighborSearcher,
+    )
+
+    assert issubclass(DiscretePDFNearestNeighborSearcher, DiscretePDFInterpolator)
+    assert issubclass(ParametrizedNearestNeighborSearcher, ParametrizedInterpolator)
+    assert not issubclass(ParametrizedNearestNeighborSearcher, DiscretePDFInterpolator)
+    assert not issubclass(DiscretePDFNearestNeighborSearcher, ParametrizedInterpolator)

--- a/pyirf/interpolation/tests/test_component_estimator_base_classes.py
+++ b/pyirf/interpolation/tests/test_component_estimator_base_classes.py
@@ -45,9 +45,6 @@ def test_BaseComponentEstimator_target_point_checks():
     def dummy_interp(target_point):
         return 42
 
-    def dummy_extrap(target_point):
-        return 43
-
     class DummyEstimator(BaseComponentEstimator):
         def __init__(self, grid_points):
             super().__init__(grid_points)
@@ -98,7 +95,7 @@ def test_BaseComponentEstimator_target_point_checks():
 
 
 def test_BaseComponentEstimator_call():
-    """Test base_estimator's __call__ """
+    """Test base_estimator's __call__"""
     from pyirf.interpolation.component_estimators import BaseComponentEstimator
 
     grid_points1D_good = np.array([1, 2, 3])
@@ -155,7 +152,7 @@ def test_ParametrizedComponentEstimator_checks():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a ParametrizedInterpolator subclass, got",
+        match="interpolator_cls must be a ParametrizedInterpolator subclass or NearestNeighborSearcher, got",
     ):
         ParametrizedComponentEstimator(
             grid_points=grid_points,
@@ -209,7 +206,7 @@ def test_DiscretePDFComponentEstimator_checks():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a DiscretePDFInterpolator subclass, got",
+        match="interpolator_cls must be a DiscretePDFInterpolator subclass or NearestNeighborSearcher, got",
     ):
         DiscretePDFComponentEstimator(
             grid_points=grid_points,
@@ -261,3 +258,119 @@ def test_DiscretePDFComponentEstimator_checks():
             bin_edges=bin_edges,
             interpolator_cls=DummyInterpolator,
         )
+
+
+def test_DiscretePDFComponentEstimator_NearestNeighbors():
+    """Test DiscretePDFComponentEstimator to be usable with NearestNeighborSearch and bin_edges
+    is ignored properly if not needed."""
+    from pyirf.interpolation.base_interpolators import DiscretePDFInterpolator
+    from pyirf.interpolation.component_estimators import DiscretePDFComponentEstimator
+    from pyirf.interpolation.nearest_neighbor_searcher import NearestNeighborSearcher
+
+    grid_points = np.array([1, 2, 3])
+    bin_edges = np.linspace(0, 1, 11)
+    bin_contents = np.array([np.full(10, x) for x in grid_points])
+
+    # NearestNeighborSearcher as interpolator, no extrapolator
+    estim = DiscretePDFComponentEstimator(
+        grid_points=grid_points,
+        bin_contents=bin_contents,
+        bin_edges=None,
+        interpolator_cls=NearestNeighborSearcher,
+        interpolator_kwargs={"norm_ord": 2},
+    )
+
+    assert np.allclose(estim(target_point=np.array([1.1])), bin_contents[0, :])
+
+    # NearestNeighborSearcher as inter- and extrapolator
+    estim = DiscretePDFComponentEstimator(
+        grid_points=grid_points,
+        bin_contents=bin_contents,
+        bin_edges=None,
+        interpolator_cls=NearestNeighborSearcher,
+        interpolator_kwargs={"norm_ord": 2},
+        extrapolator_cls=NearestNeighborSearcher,
+        extrapolator_kwargs={"norm_ord": 1},
+    )
+
+    assert np.allclose(estim(target_point=np.array([1.1])), bin_contents[0, :])
+    assert np.allclose(estim(target_point=np.array([4.1])), bin_contents[2, :])
+
+    # DummyInterpolator but NearestNeighborSeacher as extrapolaor
+    class DummyInterpolator(DiscretePDFInterpolator):
+        def interpolate(self, target_point):
+            return 42
+
+    with pytest.raises(TypeError, match="Input bin_edges is not a numpy array."):
+        DiscretePDFComponentEstimator(
+            grid_points=grid_points,
+            bin_contents=bin_contents,
+            bin_edges=None,
+            interpolator_cls=DummyInterpolator,
+            interpolator_kwargs=None,
+            extrapolator_cls=NearestNeighborSearcher,
+            extrapolator_kwargs={"norm_ord": 1},
+        )
+
+    estim = DiscretePDFComponentEstimator(
+        grid_points=grid_points,
+        bin_contents=bin_contents,
+        bin_edges=bin_edges,
+        interpolator_cls=DummyInterpolator,
+        interpolator_kwargs=None,
+        extrapolator_cls=NearestNeighborSearcher,
+        extrapolator_kwargs={"norm_ord": 1},
+    )
+
+    assert estim(target_point=np.array([1.1])) == 42
+    assert np.allclose(estim(target_point=np.array([4.1])), bin_contents[2, :])
+
+    # DummyExtrapolator but NearestNeighborSeacher as interpolaor
+    class DummyExtrapolator(DiscretePDFInterpolator):
+        def interpolate(self, target_point):
+            return 41
+
+    with pytest.raises(TypeError, match="Input bin_edges is not a numpy array."):
+        DiscretePDFComponentEstimator(
+            grid_points=grid_points,
+            bin_contents=bin_contents,
+            bin_edges=None,
+            interpolator_cls=NearestNeighborSearcher,
+            interpolator_kwargs={"norm_ord": 3},
+            extrapolator_cls=DummyExtrapolator,
+            extrapolator_kwargs=None,
+        )
+
+    estim = DiscretePDFComponentEstimator(
+        grid_points=grid_points,
+        bin_contents=bin_contents,
+        bin_edges=bin_edges,
+        interpolator_cls=NearestNeighborSearcher,
+        interpolator_kwargs={"norm_ord": 3},
+        extrapolator_cls=DummyExtrapolator,
+        extrapolator_kwargs=None,
+    )
+
+    assert np.allclose(estim(target_point=np.array([1.1])), bin_contents[0, :])
+    assert estim(target_point=np.array([4.1])) == 41
+
+
+def test_ParametrizedComponentEstimator_NearestNeighbors():
+    """Test ParametrizedComponentEstimator to be usable with NearestNeighborSearch."""
+    from pyirf.interpolation.component_estimators import ParametrizedComponentEstimator
+    from pyirf.interpolation.nearest_neighbor_searcher import NearestNeighborSearcher
+
+    grid_points = np.array([1, 2, 3])
+    params = np.array([np.full(10, x) for x in grid_points])
+
+    estim = ParametrizedComponentEstimator(
+        grid_points=grid_points,
+        params=params,
+        interpolator_cls=NearestNeighborSearcher,
+        interpolator_kwargs={"norm_ord": 2},
+        extrapolator_cls=NearestNeighborSearcher,
+        extrapolator_kwargs={"norm_ord": 1},
+    )
+
+    assert np.allclose(estim(target_point=np.array([1.1])), params[0, :])
+    assert np.allclose(estim(target_point=np.array([4.1])), params[2, :])

--- a/pyirf/interpolation/tests/test_component_estimator_base_classes.py
+++ b/pyirf/interpolation/tests/test_component_estimator_base_classes.py
@@ -152,7 +152,7 @@ def test_ParametrizedComponentEstimator_checks():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a ParametrizedInterpolator subclass or ParametrizedNearestNeighborSearcher, got",
+        match="interpolator_cls must be a ParametrizedInterpolator subclass, got",
     ):
         ParametrizedComponentEstimator(
             grid_points=grid_points,
@@ -206,7 +206,7 @@ def test_DiscretePDFComponentEstimator_checks():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a DiscretePDFInterpolator subclass or DiscretePDFNearestNeighborSearcher, got",
+        match="interpolator_cls must be a DiscretePDFInterpolator subclass, got",
     ):
         DiscretePDFComponentEstimator(
             grid_points=grid_points,
@@ -288,7 +288,7 @@ def test_DiscretePDFComponentEstimator_NearestNeighbors():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a DiscretePDFInterpolator subclass or DiscretePDFNearestNeighborSearcher, got",
+        match="interpolator_cls must be a DiscretePDFInterpolator subclass, got",
     ):
         DiscretePDFComponentEstimator(
             grid_points=grid_points,
@@ -326,7 +326,7 @@ def test_ParametrizedComponentEstimator_NearestNeighbors():
 
     with pytest.raises(
         TypeError,
-        match="interpolator_cls must be a ParametrizedInterpolator subclass or ParametrizedNearestNeighborSearcher, got",
+        match="interpolator_cls must be a ParametrizedInterpolator subclass, got",
     ):
         ParametrizedComponentEstimator(
             grid_points=grid_points,

--- a/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
@@ -27,7 +27,7 @@ def test_BaseNearestNeighborSearcher_1DGrid(grid_1d, contents):
 
     searcher = BaseNearestNeighborSearcher(grid_1d, contents, norm_ord=2)
 
-    target = np.array([[0]])
+    target = np.array([0])
     assert np.array_equal(searcher(target), contents[0, :])
 
     target = np.array([[1.9]])
@@ -42,7 +42,7 @@ def test_BaseNearestNeighborSearcher_2DGrid(grid_2d, contents):
     target = np.array([[0, 1]])
     assert np.array_equal(searcher(target), contents[0, :])
 
-    target = np.array([[3, 3]])
+    target = np.array([3, 3])
     assert np.array_equal(searcher(target), contents[-1, :])
 
 

--- a/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
@@ -22,10 +22,10 @@ def contents(grid_1d):
     )
 
 
-def test_NearestNeighborSearcher_1DGrid(grid_1d, contents):
-    from pyirf.interpolation import NearestNeighborSearcher
+def test_BaseNearestNeighborSearcher_1DGrid(grid_1d, contents):
+    from pyirf.interpolation import BaseNearestNeighborSearcher
 
-    searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=2)
+    searcher = BaseNearestNeighborSearcher(grid_1d, contents, norm_ord=2)
 
     target = np.array([[0]])
     assert np.array_equal(searcher(target), contents[0, :])
@@ -34,22 +34,10 @@ def test_NearestNeighborSearcher_1DGrid(grid_1d, contents):
     assert np.array_equal(searcher(target), contents[1, :])
 
 
-def test_NearestNeighborSearcher_2DGrid(grid_2d, contents):
-    from pyirf.interpolation import NearestNeighborSearcher
+def test_BaseNearestNeighborSearcher_2DGrid(grid_2d, contents):
+    from pyirf.interpolation import BaseNearestNeighborSearcher
 
-    searcher = NearestNeighborSearcher(grid_2d, contents, norm_ord=2)
-
-    target = np.array([[0, 1]])
-    assert np.array_equal(searcher(target), contents[0, :])
-
-    target = np.array([[3, 3]])
-    assert np.array_equal(searcher(target), contents[-1, :])
-
-
-def test_NearestNeighborSearcher_manhatten_norm(grid_2d, contents):
-    from pyirf.interpolation import NearestNeighborSearcher
-
-    searcher = NearestNeighborSearcher(grid_2d, contents, norm_ord=1)
+    searcher = BaseNearestNeighborSearcher(grid_2d, contents, norm_ord=2)
 
     target = np.array([[0, 1]])
     assert np.array_equal(searcher(target), contents[0, :])
@@ -58,17 +46,59 @@ def test_NearestNeighborSearcher_manhatten_norm(grid_2d, contents):
     assert np.array_equal(searcher(target), contents[-1, :])
 
 
-def test_NearestNeighborSearcher_wrong_norm(grid_1d, contents):
-    from pyirf.interpolation import NearestNeighborSearcher
+def test_BaseNearestNeighborSearcher_manhatten_norm(grid_2d, contents):
+    from pyirf.interpolation import BaseNearestNeighborSearcher
+
+    searcher = BaseNearestNeighborSearcher(grid_2d, contents, norm_ord=1)
+
+    target = np.array([[0, 1]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[3, 3]])
+    assert np.array_equal(searcher(target), contents[-1, :])
+
+
+def test_BaseNearestNeighborSearcher_wrong_norm(grid_1d, contents):
+    from pyirf.interpolation import BaseNearestNeighborSearcher
 
     with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
-        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=-2)
+        BaseNearestNeighborSearcher(grid_1d, contents, norm_ord=-2)
 
     with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
-        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=1.5)
+        BaseNearestNeighborSearcher(grid_1d, contents, norm_ord=1.5)
 
     with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
-        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=np.inf)
+        BaseNearestNeighborSearcher(grid_1d, contents, norm_ord=np.inf)
 
     with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
-        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord="nuc")
+        BaseNearestNeighborSearcher(grid_1d, contents, norm_ord="nuc")
+
+
+def test_DiscretePDFNearestNeighborSearcher(grid_2d, contents):
+    from pyirf.interpolation import DiscretePDFNearestNeighborSearcher
+
+    bin_edges = np.linspace(0, 1, contents.shape[-1] + 1)
+
+    searcher = DiscretePDFNearestNeighborSearcher(
+        grid_points=grid_2d, bin_edges=bin_edges, bin_contents=contents, norm_ord=1
+    )
+
+    target = np.array([[0, 1]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[3, 3]])
+    assert np.array_equal(searcher(target), contents[-1, :])
+
+
+def test_ParametrizedNearestNeighborSearcher(grid_2d, contents):
+    from pyirf.interpolation import ParametrizedNearestNeighborSearcher
+
+    searcher = ParametrizedNearestNeighborSearcher(
+        grid_points=grid_2d, params=contents, norm_ord=1
+    )
+
+    target = np.array([[0, 1]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[3, 3]])
+    assert np.array_equal(searcher(target), contents[-1, :])

--- a/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/tests/test_nearest_neighbor_searcher.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def grid_1d():
+    return np.array([[1], [2], [3], [4]])
+
+
+@pytest.fixture
+def grid_2d():
+    return np.array([[1, 1], [1, 2], [2, 1], [2, 2]])
+
+
+@pytest.fixture
+def contents(grid_1d):
+    return np.array(
+        [
+            [[np.full(10, x), np.full(10, x / 2)], [np.full(10, 2 * x), np.zeros(10)]]
+            for x in grid_1d
+        ]
+    )
+
+
+def test_NearestNeighborSearcher_1DGrid(grid_1d, contents):
+    from pyirf.interpolation import NearestNeighborSearcher
+
+    searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=2)
+
+    target = np.array([[0]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[1.9]])
+    assert np.array_equal(searcher(target), contents[1, :])
+
+
+def test_NearestNeighborSearcher_2DGrid(grid_2d, contents):
+    from pyirf.interpolation import NearestNeighborSearcher
+
+    searcher = NearestNeighborSearcher(grid_2d, contents, norm_ord=2)
+
+    target = np.array([[0, 1]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[3, 3]])
+    assert np.array_equal(searcher(target), contents[-1, :])
+
+
+def test_NearestNeighborSearcher_manhatten_norm(grid_2d, contents):
+    from pyirf.interpolation import NearestNeighborSearcher
+
+    searcher = NearestNeighborSearcher(grid_2d, contents, norm_ord=1)
+
+    target = np.array([[0, 1]])
+    assert np.array_equal(searcher(target), contents[0, :])
+
+    target = np.array([[3, 3]])
+    assert np.array_equal(searcher(target), contents[-1, :])
+
+
+def test_NearestNeighborSearcher_wrong_norm(grid_1d, contents):
+    from pyirf.interpolation import NearestNeighborSearcher
+
+    with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
+        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=-2)
+
+    with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
+        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=1.5)
+
+    with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
+        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord=np.inf)
+
+    with pytest.raises(ValueError, match="Only positiv integers allowed for norm_ord"):
+        searcher = NearestNeighborSearcher(grid_1d, contents, norm_ord="nuc")


### PR DESCRIPTION
This PR adds an NearestNeighborSearcher Inter-/Extrapolation class for convenience. The name was chosen to reflect that this does not do any Inter-/Extrapolation at all.