### PR TITLE
Extrapolator Structure and NearestSimplexExtrapolator for Parametrized Components

### DIFF
--- a/docs/changes/236.feature.rst
+++ b/docs/changes/236.feature.rst
@@ -1,0 +1,3 @@
+This PR adds a base structure for extrapolators similar to the interpolation case 
+as well as a first extrapolator for parametrized components, extrapolating from the 
+nearest simplex in one or two dimensions.

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -1,5 +1,5 @@
 """
-Collection of interpolation methods
+Collection of interpolation and extrapolation methods
 """
 
 from .base_extrapolators import (
@@ -28,6 +28,7 @@ from .nearest_neighbor_searcher import (
     DiscretePDFNearestNeighborSearcher,
     ParametrizedNearestNeighborSearcher,
 )
+from .nearest_simplex_extrapolator import ParametrizedNearestSimplexExtrapolator
 from .quantile_interpolator import QuantileInterpolator
 
 __all__ = [
@@ -45,6 +46,7 @@ __all__ = [
     "ParametrizedComponentEstimator",
     "ParametrizedInterpolator",
     "ParametrizedNearestNeighborSearcher",
+    "ParametrizedNearestSimplexExtrapolator",
     "QuantileInterpolator",
     "EffectiveAreaEstimator",
     "RadMaxEstimator",

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -2,6 +2,11 @@
 Collection of interpolation methods
 """
 
+from .base_extrapolators import (
+    BaseExtrapolator,
+    DiscretePDFExtrapolator,
+    ParametrizedExtrapolator,
+)
 from .base_interpolators import (
     BaseInterpolator,
     DiscretePDFInterpolator,
@@ -29,6 +34,9 @@ __all__ = [
     "BaseComponentEstimator",
     "BaseInterpolator",
     "BaseNearestNeighborSearcher",
+    "BaseExtrapolator",
+    "DiscretePDFExtrapolator",
+    "ParametrizedExtrapolator",
     "DiscretePDFComponentEstimator",
     "DiscretePDFInterpolator",
     "DiscretePDFNearestNeighborSearcher",

--- a/pyirf/interpolation/base_extrapolators.py
+++ b/pyirf/interpolation/base_extrapolators.py
@@ -30,7 +30,7 @@ class BaseExtrapolator(metaclass=ABCMeta):
 
     @abstractmethod
     def extrapolate(self, target_point):
-        """Overridable function for the actual interpolation code"""
+        """Overridable function for the actual extrapolation code"""
 
     def __call__(self, target_point):
         """Providing a common __call__ interface
@@ -96,7 +96,7 @@ class DiscretePDFExtrapolator(BaseExtrapolator):
             Content of each bin in bin_edges for
             each point in grid_points. First dimesion has to correspond to number
             of grid_points, last dimension has to correspond to number of bins for
-            the quantity that should be interpolated (e.g. the Migra axis for EDisp)
+            the quantity that should be extrapolated (e.g. the Migra axis for EDisp)
 
 
         Note

--- a/pyirf/interpolation/base_extrapolators.py
+++ b/pyirf/interpolation/base_extrapolators.py
@@ -1,0 +1,110 @@
+"""Base classes for extrapolators"""
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+from pyirf.binning import bin_center
+
+__all__ = ["BaseExtrapolator", "ParametrizedExtrapolator", "DiscretePDFExtrapolator"]
+
+
+class BaseExtrapolator(metaclass=ABCMeta):
+    """
+    Base class for all extrapolators, only knowing grid-points,
+    providing a common __call__-interface.
+    """
+
+    def __init__(self, grid_points):
+        """BaseExtrapolator
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(n_points, n_dims):
+            Grid points at which templates exist
+
+        """
+        self.grid_points = grid_points
+        if self.grid_points.ndim == 1:
+            self.grid_points = self.grid_points.reshape(*self.grid_points.shape, 1)
+        self.n_points = self.grid_points.shape[0]
+        self.grid_dim = self.grid_points.shape[1]
+
+    @abstractmethod
+    def extrapolate(self, target_point):
+        """Overridable function for the actual interpolation code"""
+
+    def __call__(self, target_point):
+        """Providing a common __call__ interface
+
+        Parameters
+        ----------
+        target_point: np.ndarray, shape=(1, n_dims)
+            Target for extrapolation
+
+        Returns
+        -------
+        Extrapolated result.
+        """
+        return self.extrapolate(target_point=target_point)
+
+
+class ParametrizedExtrapolator(BaseExtrapolator):
+    """
+    Base class for all extrapolators used with IRF components that can be
+    treated independently, e.g. parametrized ones like 3Gauss
+    but also AEff. Derived from pyirf.interpolation.BaseExtrapolator
+    """
+
+    def __init__(self, grid_points, params):
+        """ParametrizedExtrapolator
+
+        Parameters
+        ----------
+        grid_points, np.ndarray, shape=(n_points, n_dims)
+            Grid points at which templates exist
+        params: np.ndarray, shape=(n_points, ..., n_params)
+            Corresponding parameter values at each point in grid_points.
+            First dimesion has to correspond to number of grid_points
+
+        Note
+        ----
+            Also calls pyirf.interpolation.BaseExtrapolators.__init__
+        """
+        super().__init__(grid_points)
+
+        self.params = params
+
+        if self.params.ndim == 1:
+            self.params = self.params[..., np.newaxis]
+
+
+class DiscretePDFExtrapolator(BaseExtrapolator):
+    """
+    Base class for all extrapolators used with binned IRF components like EDisp.
+    Derived from pyirf.interpolation.BaseExtrapolator
+    """
+
+    def __init__(self, grid_points, bin_edges, bin_contents):
+        """DiscretePDFExtrapolator
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(n_points, n_dims)
+            Grid points at which templates exist
+        bin_edges: np.ndarray, shape=(n_bins+1)
+            Edges of the data binning
+        bin_content: np.ndarray, shape=(n_points, ..., n_bins)
+            Content of each bin in bin_edges for
+            each point in grid_points. First dimesion has to correspond to number
+            of grid_points, last dimension has to correspond to number of bins for
+            the quantity that should be interpolated (e.g. the Migra axis for EDisp)
+
+
+        Note
+        ----
+            Also calls pyirf.interpolation.BaseExtrapolators.__init__
+        """
+        super().__init__(grid_points)
+
+        self.bin_edges = bin_edges
+        self.bin_mids = bin_center(self.bin_edges)
+        self.bin_contents = bin_contents

--- a/pyirf/interpolation/component_estimators.py
+++ b/pyirf/interpolation/component_estimators.py
@@ -3,18 +3,13 @@ import warnings
 
 import astropy.units as u
 import numpy as np
-from pyirf.interpolation.base_interpolators import (
-    DiscretePDFInterpolator,
-    ParametrizedInterpolator,
-)
-from pyirf.interpolation.griddata_interpolator import GridDataInterpolator
-from pyirf.interpolation.nearest_neighbor_searcher import (
-    DiscretePDFNearestNeighborSearcher,
-    ParametrizedNearestNeighborSearcher,
-)
-from pyirf.interpolation.quantile_interpolator import QuantileInterpolator
 from pyirf.utils import cone_solid_angle
 from scipy.spatial import Delaunay
+
+from .base_extrapolators import DiscretePDFExtrapolator, ParametrizedExtrapolator
+from .base_interpolators import DiscretePDFInterpolator, ParametrizedInterpolator
+from .griddata_interpolator import GridDataInterpolator
+from .quantile_interpolator import QuantileInterpolator
 
 __all__ = [
     "BaseComponentEstimator",
@@ -196,15 +191,17 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
         TypeError:
             When bin_edges is not a np.ndarray.
         TypeError:
-            When bin_content is not a np.ndarray
+            When bin_content is not a np.ndarray..
         TypeError:
             When interpolator_cls is not a DiscretePDFInterpolator subclass.
+        TypeError:
+            When extrapolator_cls is not a DiscretePDFExtrapolator subclass.
         ValueError:
             When number of bins in bin_edges and contents in bin_contents is
             not matching.
         ValueError:
             When number of histograms in bin_contents and points in grid_points
-            is not matching
+            is not matching.
 
         Note
         ----
@@ -248,6 +245,10 @@ class DiscretePDFComponentEstimator(BaseComponentEstimator):
 
         if extrapolator_cls is None:
             self.extrapolator = None
+        elif not issubclass(extrapolator_cls, DiscretePDFExtrapolator):
+            raise TypeError(
+                f"extrapolator_cls must be a DiscretePDFExtrapolator subclass, got {extrapolator_cls}"
+            )
         else:
             self.extrapolator = extrapolator_cls(
                 grid_points, bin_edges, bin_contents, **extrapolator_kwargs
@@ -301,9 +302,11 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
         TypeError:
             When interpolator_cls is not a ParametrizedInterpolator subclass.
         TypeError:
-            When params is not a np.ndarray
+            When extrapolator_cls is not a ParametrizedExtrapolator subclass.
+        TypeError:
+            When params is not a np.ndarray.
         ValueError:
-            When number of points grid_points and params is not matching
+            When number of points grid_points and params is not matching.
 
         Note
         ----
@@ -336,6 +339,10 @@ class ParametrizedComponentEstimator(BaseComponentEstimator):
 
         if extrapolator_cls is None:
             self.extrapolator = None
+        elif not issubclass(extrapolator_cls, ParametrizedExtrapolator):
+            raise TypeError(
+                f"extrapolator_cls must be a ParametrizedExtrapolator subclass, got {extrapolator_cls}"
+            )
         else:
             self.extrapolator = extrapolator_cls(
                 grid_points, params, **extrapolator_kwargs

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -127,9 +127,9 @@ def linesegment_1D_interpolation_coefficients(grid_points, target_point):
     return np.einsum("...j, ji -> ...i", (target_point - m0) ** j, np.linalg.inv(m_ij))
 
 
-def baryzentric_2D_interpolation_coefficients(grid_points, target_point):
+def barycentric_2D_interpolation_coefficients(grid_points, target_point):
     """
-    Compute baryzetric 2D interpolation coefficients for triangular
+    Compute barycetric 2D interpolation coefficients for triangular
     interpolation, see e.g. [1]
 
     Parameters
@@ -137,7 +137,7 @@ def baryzentric_2D_interpolation_coefficients(grid_points, target_point):
     grid_points: np.ndarray, shape=(3, 2)
         Points spanning a triangle in which
     target_point: np.ndarray, shape=(1, 2)
-        Value at which baryzentric interpolation is needed
+        Value at which barycentric interpolation is needed
 
     Returns
     -------
@@ -309,7 +309,7 @@ class MomentMorphInterpolator(DiscretePDFInterpolator):
         simplex_inds = self.triangulation.simplices[
             self.triangulation.find_simplex(target_point)
         ].squeeze()
-        coefficients = baryzentric_2D_interpolation_coefficients(
+        coefficients = barycentric_2D_interpolation_coefficients(
             grid_points=self.grid_points[simplex_inds],
             target_point=target_point,
         )

--- a/pyirf/interpolation/moment_morph_interpolator.py
+++ b/pyirf/interpolation/moment_morph_interpolator.py
@@ -129,7 +129,7 @@ def linesegment_1D_interpolation_coefficients(grid_points, target_point):
 
 def barycentric_2D_interpolation_coefficients(grid_points, target_point):
     """
-    Compute barycetric 2D interpolation coefficients for triangular
+    Compute barycentric 2D interpolation coefficients for triangular
     interpolation, see e.g. [1]
 
     Parameters

--- a/pyirf/interpolation/nearest_neighbor_searcher.py
+++ b/pyirf/interpolation/nearest_neighbor_searcher.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .base_extrapolators import DiscretePDFExtrapolator, ParametrizedExtrapolator
 from .base_interpolators import (
     BaseInterpolator,
     DiscretePDFInterpolator,
@@ -136,6 +137,7 @@ class DiscretePDFNearestNeighborSearcher(BaseNearestNeighborSearcher):
 
 
 DiscretePDFInterpolator.register(DiscretePDFNearestNeighborSearcher)
+DiscretePDFExtrapolator.register(DiscretePDFNearestNeighborSearcher)
 
 
 class ParametrizedNearestNeighborSearcher(BaseNearestNeighborSearcher):
@@ -170,3 +172,4 @@ class ParametrizedNearestNeighborSearcher(BaseNearestNeighborSearcher):
 
 
 ParametrizedInterpolator.register(ParametrizedNearestNeighborSearcher)
+ParametrizedExtrapolator.register(ParametrizedNearestNeighborSearcher)

--- a/pyirf/interpolation/nearest_simplex_extrapolator.py
+++ b/pyirf/interpolation/nearest_simplex_extrapolator.py
@@ -1,0 +1,112 @@
+"""
+Extrapolators for Parametrized and DiscretePDF components extrapolating from the 
+nearest simplex
+"""
+import numpy as np
+from scipy.spatial import Delaunay
+
+from .base_extrapolators import ParametrizedExtrapolator
+from .moment_morph_interpolator import (
+    barycentric_2D_interpolation_coefficients,
+    linesegment_1D_interpolation_coefficients,
+)
+
+__all__ = ["ParametrizedNearestSimplexExtrapolator"]
+
+
+class ParametrizedNearestSimplexExtrapolator(ParametrizedExtrapolator):
+    def __init__(self, grid_points, params):
+        """
+        Extrapolator class using linear extrapolation in one ore two
+        grid-dimensions.
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(N, ...)
+            Grid points at which templates exist. May be one ot two dimensional.
+        params: np.ndarray, shape=(N, ...)
+            Array of corresponding parameter values at each point in grid_points.
+            First dimesion has to correspond to number of grid_points
+
+        Note
+        ----
+            Also calls pyirf.interpolation.ParametrizedInterpolator.__init__.
+        """
+        super().__init__(grid_points, params)
+
+        if self.grid_dim == 2:
+            self.triangulation = Delaunay(self.grid_points)
+        elif self.grid_dim > 2:
+            raise NotImplementedError(
+                "Extrapolation in more then two dimension not impemented."
+            )
+
+    def _extrapolate1D(self, segment_inds, target_point):
+        """
+        Function to compute extrapolation coefficients for a target_point on a
+        specified grid segment and extrapolate from this subset
+        """
+        coefficients = linesegment_1D_interpolation_coefficients(
+            grid_points=self.grid_points[segment_inds],
+            target_point=target_point.squeeze(),
+        )
+
+        # reshape to be broadcastable
+        coefficients = coefficients.reshape(
+            coefficients.shape[0], *np.ones(self.params.ndim - 1, "int")
+        )
+
+        return np.sum(coefficients * self.params[segment_inds, :], axis=0)[
+            np.newaxis, :
+        ]
+
+    def _extrapolate2D(self, simplex_inds, target_point):
+        """
+        Function to compute extrapolation coeficcients and extrapolate from the nearest
+        simplex by extending barycentric interpolation
+        """
+        coefficients = barycentric_2D_interpolation_coefficients(
+            grid_points=self.grid_points[simplex_inds],
+            target_point=target_point,
+        )
+
+        # reshape to be broadcastable
+        coefficients = coefficients.reshape(
+            coefficients.shape[0], *np.ones(self.params.ndim - 1, "int")
+        )
+
+        return np.sum(coefficients * self.params[simplex_inds, :], axis=0)[
+            np.newaxis, :
+        ]
+
+    def extrapolate(self, target_point):
+        """
+        Takes a grid of scalar values for a bunch of different parameters
+        and extrapolte it to given value of those parameters.
+
+        Parameters
+        ----------
+        target_point: numpy.ndarray
+            Value for which the extrapolation is performed (target point)
+
+        Returns
+        -------
+        values: numpy.ndarray, shape=(1,...)
+            Extrapolated values
+
+        """
+        if self.grid_dim == 1:
+            if target_point < self.grid_points.min():
+                segment_inds = np.array([0, 1], "int")
+            else:
+                segment_inds = np.array([-2, -1], "int")
+
+            extrapolant = self._extrapolate1D(segment_inds, target_point)
+        elif self.grid_dim == 2:
+            dists = self.triangulation.plane_distance(target_point)
+            nearest_simplex_ind = np.argmax(dists)
+            simplex_indices = self.triangulation.simplices[nearest_simplex_ind]
+
+            extrapolant = self._extrapolate2D(simplex_indices, target_point)
+
+        return extrapolant

--- a/pyirf/interpolation/tests/test_base_extrapolators.py
+++ b/pyirf/interpolation/tests/test_base_extrapolators.py
@@ -17,7 +17,7 @@ def test_BaseExtrapolator_instantiation():
         BaseExtrapolator(grid_points1D)
 
     class DummyBaseExtrapolator(BaseExtrapolator):
-        def extrapolate(self, target_point, **kwargs):
+        def extrapolate(self, target_point):
             return 42
 
     interp1D = DummyBaseExtrapolator(grid_points1D)
@@ -42,7 +42,7 @@ def test_ParametrizedExtrapolator_instantiation():
         ParametrizedExtrapolator(grid_points1D, params)
 
     class DummyParametrizedExtrapolator(ParametrizedExtrapolator):
-        def extrapolate(self, target_point, **kwargs):
+        def extrapolate(self, target_point):
             return 42
 
     interp1D = DummyParametrizedExtrapolator(grid_points1D, params)
@@ -50,6 +50,11 @@ def test_ParametrizedExtrapolator_instantiation():
 
     interp2D = DummyParametrizedExtrapolator(grid_points2D, params)
     assert interp2D(target2D) == 42
+
+    # If only one param per point exists and param.shape is not (n_points, 1)
+    # they should be broadcasted internally
+    interp1D = DummyParametrizedExtrapolator(grid_points1D, params.squeeze())
+    assert interp1D(target1D) == 42
 
 
 def test_DiscretePDFExtrapolator_instantiation():
@@ -68,7 +73,7 @@ def test_DiscretePDFExtrapolator_instantiation():
         DiscretePDFExtrapolator(grid_points1D, bin_edges, bin_content)
 
     class DummyBinnedExtrapolator(DiscretePDFExtrapolator):
-        def extrapolate(self, target_point, **kwargs):
+        def extrapolate(self, target_point):
             return 42
 
     interp1D = DummyBinnedExtrapolator(grid_points1D, bin_edges, bin_content)

--- a/pyirf/interpolation/tests/test_base_extrapolators.py
+++ b/pyirf/interpolation/tests/test_base_extrapolators.py
@@ -1,0 +1,93 @@
+"""Tests for base extrapolator classes"""
+import numpy as np
+import pytest
+
+
+def test_BaseExtrapolator_instantiation():
+    """Test ParametrizedExtrapolator initialization"""
+    from pyirf.interpolation.base_extrapolators import BaseExtrapolator
+
+    grid_points1D = np.array([1, 2, 3])
+    target1D = np.array([[0]])
+
+    grid_points2D = np.array([[1, 1], [2, 1], [1.5, 1.5]])
+    target2D = np.array([[0.25, 0.25]])
+
+    with pytest.raises(TypeError):  # Abstract class, cannot be instantiated
+        BaseExtrapolator(grid_points1D)
+
+    class DummyBaseExtrapolator(BaseExtrapolator):
+        def extrapolate(self, target_point, **kwargs):
+            return 42
+
+    interp1D = DummyBaseExtrapolator(grid_points1D)
+    assert interp1D(target1D) == 42
+
+    interp2D = DummyBaseExtrapolator(grid_points2D)
+    assert interp2D(target2D) == 42
+
+
+def test_ParametrizedExtrapolator_instantiation():
+    """Test ParametrizedExtrapolator initialization"""
+    from pyirf.interpolation.base_extrapolators import ParametrizedExtrapolator
+
+    grid_points1D = np.array([1, 2, 3])
+    grid_points2D = np.array([[1, 1], [2, 1], [1.5, 1.5]])
+    target1D = np.array([[0]])
+    target2D = np.array([[0.25, 0.25]])
+
+    params = np.array([[1], [2], [3]])
+
+    with pytest.raises(TypeError):  # Abstract class, cannot be instantiated
+        ParametrizedExtrapolator(grid_points1D, params)
+
+    class DummyParametrizedExtrapolator(ParametrizedExtrapolator):
+        def extrapolate(self, target_point, **kwargs):
+            return 42
+
+    interp1D = DummyParametrizedExtrapolator(grid_points1D, params)
+    assert interp1D(target1D) == 42
+
+    interp2D = DummyParametrizedExtrapolator(grid_points2D, params)
+    assert interp2D(target2D) == 42
+
+
+def test_DiscretePDFExtrapolator_instantiation():
+    """Test DiscretePDFExtrapolator initialization and sanity checks"""
+    from pyirf.interpolation.base_extrapolators import DiscretePDFExtrapolator
+
+    grid_points1D = np.array([1, 2, 3])
+    grid_points2D = np.array([[1, 1], [2, 1], [1.5, 1.5]])
+    target1D = np.array([[0]])
+    target2D = np.array([[0.25, 0.25]])
+
+    bin_edges = np.linspace(-1, 1, 11)
+    bin_content = np.ones(shape=(len(grid_points1D), len(bin_edges) - 1))
+
+    with pytest.raises(TypeError):  # Abstract class, cannot be instantiated
+        DiscretePDFExtrapolator(grid_points1D, bin_edges, bin_content)
+
+    class DummyBinnedExtrapolator(DiscretePDFExtrapolator):
+        def extrapolate(self, target_point, **kwargs):
+            return 42
+
+    interp1D = DummyBinnedExtrapolator(grid_points1D, bin_edges, bin_content)
+    assert interp1D(target1D) == 42
+
+    interp2D = DummyBinnedExtrapolator(grid_points2D, bin_edges, bin_content)
+    assert interp2D(target2D) == 42
+
+
+def test_virtual_subclasses():
+    """Tests that corresponding nearest neighbor seacher are virtual sublasses of extrapolators"""
+    from pyirf.interpolation import (
+        DiscretePDFExtrapolator,
+        DiscretePDFNearestNeighborSearcher,
+        ParametrizedExtrapolator,
+        ParametrizedNearestNeighborSearcher,
+    )
+
+    assert issubclass(DiscretePDFNearestNeighborSearcher, DiscretePDFExtrapolator)
+    assert issubclass(ParametrizedNearestNeighborSearcher, ParametrizedExtrapolator)
+    assert not issubclass(ParametrizedNearestNeighborSearcher, DiscretePDFExtrapolator)
+    assert not issubclass(DiscretePDFNearestNeighborSearcher, ParametrizedExtrapolator)

--- a/pyirf/interpolation/tests/test_moment_morph_interpolator.py
+++ b/pyirf/interpolation/tests/test_moment_morph_interpolator.py
@@ -165,43 +165,43 @@ def test_linesegment_1D_interpolation_coefficients():
     assert np.all(np.logical_and(res < 1, res > 0))
 
 
-def test_baryzentric_2D_interpolation_coefficients():
+def test_barycentric_2D_interpolation_coefficients():
     from pyirf.interpolation.moment_morph_interpolator import (
-        baryzentric_2D_interpolation_coefficients,
+        barycentric_2D_interpolation_coefficients,
     )
 
     grid_points = np.array([[20, 20], [60, 20], [40, 60]])
     target_point = np.array([20, 20])
 
     assert np.allclose(
-        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        barycentric_2D_interpolation_coefficients(grid_points, target_point),
         np.array([1, 0, 0]),
     )
 
     target_point = np.array([60, 20])
 
     assert np.allclose(
-        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        barycentric_2D_interpolation_coefficients(grid_points, target_point),
         np.array([0, 1, 0]),
     )
 
     target_point = np.array([40, 60])
 
     assert np.allclose(
-        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        barycentric_2D_interpolation_coefficients(grid_points, target_point),
         np.array([0, 0, 1]),
     )
 
     target_point = np.array([40, 20])
 
     assert np.allclose(
-        baryzentric_2D_interpolation_coefficients(grid_points, target_point),
+        barycentric_2D_interpolation_coefficients(grid_points, target_point),
         np.array([0.5, 0.5, 0]),
     )
 
     # Barycenter of triangle
     target_point = np.array([40, 100 / 3])
-    res = baryzentric_2D_interpolation_coefficients(grid_points, target_point)
+    res = barycentric_2D_interpolation_coefficients(grid_points, target_point)
 
     assert np.allclose(res, np.array([1, 1, 1]) / 3)
 
@@ -226,13 +226,13 @@ def test_moment_morph_estimation1D(bins, simple_1D_data):
 
 def test_moment_morph_estimation2D(bins, simple_2D_data):
     from pyirf.interpolation.moment_morph_interpolator import (
-        baryzentric_2D_interpolation_coefficients,
+        barycentric_2D_interpolation_coefficients,
         moment_morph_estimation,
     )
 
     grid, target, bin_contents, truth = simple_2D_data.values()
 
-    coeffs = baryzentric_2D_interpolation_coefficients(grid, target)
+    coeffs = barycentric_2D_interpolation_coefficients(grid, target)
     res = moment_morph_estimation(bins, bin_contents, coeffs)
 
     assert np.isclose(np.sum(res), 1)

--- a/pyirf/interpolation/tests/test_nearest_simplex_extrapolator.py
+++ b/pyirf/interpolation/tests/test_nearest_simplex_extrapolator.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pytest
+
+
+def test_ParametrizedNearestSimplexExtrapolator_1DGrid():
+    """Test ParametrizedNearestSimplexExtrapolator on a 1D Grid with linearly varying data"""
+    from pyirf.interpolation import ParametrizedNearestSimplexExtrapolator
+
+    grid_points = np.array([[0], [1], [2]])
+
+    slope = np.array([[[0, 1], [1, 1]], [[0, 2], [2, 3]], [[0, 3], [3, 5]]])
+    dummy_data1 = grid_points[0] * slope + 1
+    dummy_data2 = grid_points[1] * slope + 1
+    dummy_data3 = grid_points[2] * slope + 1
+
+    dummy_data = np.array([dummy_data1, dummy_data2, dummy_data3])
+
+    interpolator = ParametrizedNearestSimplexExtrapolator(
+        grid_points=grid_points,
+        params=dummy_data,
+    )
+    target_point1 = np.array([3])
+    interpolant1 = interpolator(target_point1)
+
+    dummy_data_target1 = 3 * slope + 1
+
+    assert np.allclose(interpolant1, dummy_data_target1)
+    assert interpolant1.shape == (1, *dummy_data.shape[1:])
+
+    target_point2 = np.array([[-2.5]])
+    interpolant2 = interpolator(target_point2)
+
+    dummy_data_target2 = -2.5 * slope + 1
+
+    assert np.allclose(interpolant2, dummy_data_target2)
+    assert interpolant2.shape == (1, *dummy_data.shape[1:])
+
+
+def test_ParametrizedNearestSimplexExtrapolator_2DGrid():
+    """Test ParametrizedNearestSimplexExtrapolator on a 2D Grid with independently, linearly
+    varying data in both grid dimensions"""
+    from pyirf.interpolation import ParametrizedNearestSimplexExtrapolator
+
+    grid_points = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+    slope = np.array([[[0, 1], [1, 1]], [[0, 2], [2, 3]], [[3, 0], [3, 5]]])
+    intercept = np.array([[[0, 1], [1, 1]], [[0, -1], [-1, -1]], [[10, 11], [11, 11]]])
+
+    # Create 3 times 2 linear samples, each of the form (mx * px + my * py + nx + ny)
+    # with slope m, intercept n at each grid_point p
+    dummy_data = np.array(
+        [
+            np.array(
+                [
+                    np.dot((m.T * p + n), np.array([1, 1]))
+                    for m, n in zip(slope, intercept)
+                ]
+            ).squeeze()
+            for p in grid_points
+        ]
+    )
+
+    interpolator = ParametrizedNearestSimplexExtrapolator(
+        grid_points=grid_points,
+        params=dummy_data,
+    )
+
+    target_point1 = np.array([5.5, 3.5])
+    interpolant1 = interpolator(target_point1)
+    dummy_data_target1 = np.array(
+        [
+            np.dot((m.T * target_point1 + n), np.array([1, 1]))
+            for m, n in zip(slope, intercept)
+        ]
+    ).squeeze()
+
+    assert np.allclose(interpolant1.squeeze(), dummy_data_target1)
+    assert interpolant1.shape == (1, *dummy_data.shape[1:])
+
+    target_point2 = np.array([[-2.5, -5.5]])
+    interpolant2 = interpolator(target_point2)
+
+    dummy_data_target2 = np.array(
+        [
+            np.dot((m.T * target_point2 + n), np.array([1, 1]))
+            for m, n in zip(slope, intercept)
+        ]
+    ).squeeze()
+
+    assert np.allclose(interpolant2, dummy_data_target2)
+    assert interpolant2.shape == (1, *dummy_data.shape[1:])
+
+
+def test_ParametrizedNearestSimplexExtrapolator_3DGrid():
+    """Test ParametrizedNearestSimplexExtrapolator on a 3D Grid. which is currently
+    not implemented"""
+    from pyirf.interpolation import ParametrizedNearestSimplexExtrapolator
+
+    grid_points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0]])
+    dummy_data = np.array([[0, 1], [1, 1], [0, 2], [2, 3]])
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Extrapolation in more then two dimension not impemented.",
+    ):
+        ParametrizedNearestSimplexExtrapolator(
+            grid_points=grid_points,
+            params=dummy_data,
+        )


### PR DESCRIPTION
This adds a BaseExtrapolator structure similar to the BaseInterpolators as well as a first Extrapolator usable with parametrized components. The actual extrapolator extends a linear interpolation beyond the template points in 1D and a baryzentric interpolation beyond the convex hull of the grid in 2D. Extrapolation in more then 2D is not implemented.