### PR TITLE
Add lower viewcone limit

### DIFF
--- a/docs/changes/239.api.rst
+++ b/docs/changes/239.api.rst
@@ -1,0 +1,3 @@
+Replace single ``viewcone`` argument of ``SimulationInfo`` with
+``viewcone_min`` and ``viewcone_max``, e.g. to correctly enable
+ring wobble simulations.

--- a/docs/notebooks/fact_example.ipynb
+++ b/docs/notebooks/fact_example.ipynb
@@ -99,7 +99,8 @@
     "    spectral_index=-2.7,\n",
     "    n_showers=12600000,\n",
     "    max_impact=300 * u.m,\n",
-    "    viewcone=0 * u.deg,\n",
+    "    viewcone_min=0 * u.deg,\n",
+    "    viewcone_max=0 * u.deg,\n",
     ")"
    ]
   },
@@ -301,6 +302,7 @@
     "\n",
     "plt.xlim(true_energy_bins.min().to_value(u.GeV), true_energy_bins.max().to_value(u.GeV))    \n",
     "plt.yscale('log')\n",
+    "plt.xscale('log')\n",
     "plt.legend()\n",
     "\n",
     "print(aeff_gammapy)"
@@ -504,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,9 @@
 name: pyirf
 
 channels:
-  - default
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.11
   - numpy
   - ipython
   - jupyter

--- a/pyirf/irf/tests/test_effective_area.py
+++ b/pyirf/irf/tests/test_effective_area.py
@@ -34,7 +34,8 @@ def test_effective_area_per_energy():
         energy_max=true_energy_bins[-1],
         max_impact=100 / np.sqrt(np.pi) * u.m,  # this should give a nice round area
         spectral_index=-2,
-        viewcone=0 * u.deg,
+        viewcone_min=0 * u.deg,
+        viewcone_max=0 * u.deg,
     )
 
     area = effective_area_per_energy(selected_events, simulation_info, true_energy_bins)
@@ -80,7 +81,8 @@ def test_effective_area_energy_fov():
         energy_max=true_energy_bins[-1],
         max_impact=100 / np.sqrt(np.pi) * u.m,  # this should give a nice round area
         spectral_index=-2,
-        viewcone=fov_offset_bins[-1],
+        viewcone_min=0 * u.deg,
+        viewcone_max=fov_offset_bins[-1],
     )
 
     area = effective_area_per_energy_and_fov(

--- a/pyirf/simulations.py
+++ b/pyirf/simulations.py
@@ -23,8 +23,10 @@ class SimulatedEventsInfo:
         Maximum simulated impact parameter
     spectral_index: float
         Spectral Index of the simulated power law with sign included.
-    viewcone: u.Quantity[angle]
-        Opening angle of the viewcone
+    viewcone_min: u.Quantity[angle]
+        Inner angle of the viewcone
+    viewcone_max: u.Quantity[angle]
+        Outer angle of the viewcone
     """
 
     __slots__ = (

--- a/pyirf/simulations.py
+++ b/pyirf/simulations.py
@@ -196,6 +196,12 @@ def _powerlaw_pdf_integral(index, e_low, e_high, e_min, e_max):
 
 
 def _viewcone_pdf_integral(viewcone_min, viewcone_max, fov_low, fov_high):
+    """
+    CORSIKA draws particles in the viewcone uniform per solid angle between
+    viewcone_min and viewcone_max, the associated pdf is:
+
+    pdf(theta, theta_min, theta_max) = sin(theta) / (cos(theta_min) - cos(theta_max))
+    """
     scalar = np.asanyarray(fov_low).ndim == 0
 
     fov_low = np.atleast_1d(fov_low)

--- a/pyirf/simulations.py
+++ b/pyirf/simulations.py
@@ -33,14 +33,15 @@ class SimulatedEventsInfo:
         "energy_max",
         "max_impact",
         "spectral_index",
-        "viewcone",
+        "viewcone_min",
+        "viewcone_max",
     )
 
     @u.quantity_input(
-        energy_min=u.TeV, energy_max=u.TeV, max_impact=u.m, viewcone=u.deg
+        energy_min=u.TeV, energy_max=u.TeV, max_impact=u.m, viewcone_min=u.deg, viewcone_max=u.deg
     )
     def __init__(
-        self, n_showers, energy_min, energy_max, max_impact, spectral_index, viewcone
+        self, n_showers, energy_min, energy_max, max_impact, spectral_index, viewcone_min, viewcone_max,
     ):
         #: Total number of simulated showers, if reuse was used, this must
         #: already include reuse
@@ -53,8 +54,10 @@ class SimulatedEventsInfo:
         self.max_impact = max_impact
         #: Spectral index of the simulated power law with sign included
         self.spectral_index = spectral_index
-        #: Opening angle of the viewcone
-        self.viewcone = viewcone
+        #: Inner viewcone angle
+        self.viewcone_min = viewcone_min
+        #: Outer viewcone angle
+        self.viewcone_max = viewcone_max
 
         if spectral_index > -1:
             raise ValueError("spectral index must be <= -1")
@@ -128,16 +131,7 @@ class SimulatedEventsInfo:
         fov_bins = fov_bins
         fov_low = fov_bins[:-1]
         fov_high = fov_bins[1:]
-
-        fov_integral = _viewcone_pdf_integral(self.viewcone, fov_low, fov_high)
-        viewcone = self.viewcone
-        # check if any of the bins are outside the max viewcone
-        fov_integral = np.where(fov_high <= viewcone, fov_integral, 0)
-
-        # identify the bin with the maximum viewcone inside
-        mask = (viewcone > fov_low) & (viewcone < fov_high)
-        fov_integral[mask] = _viewcone_pdf_integral(viewcone, fov_low[mask], viewcone)
-
+        fov_integral = _viewcone_pdf_integral(self.viewcone_min, self.viewcone_max, fov_low, fov_high)
         return self.n_showers * fov_integral
 
     @u.quantity_input(energy_bins=u.TeV, fov_bins=u.deg)
@@ -180,7 +174,8 @@ class SimulatedEventsInfo:
             f"energy_max={self.energy_max:.2f}, "
             f"spectral_index={self.spectral_index:.1f}, "
             f"max_impact={self.max_impact:.2f}, "
-            f"viewcone={self.viewcone}"
+            f"viewcone_min={self.viewcone_min}"
+            f"viewcone_max={self.viewcone_max}"
             ")"
         )
 
@@ -198,12 +193,26 @@ def _powerlaw_pdf_integral(index, e_low, e_high, e_min, e_max):
     return e_term * normalization
 
 
-def _viewcone_pdf_integral(viewcone, fov_low, fov_high):
-    if viewcone.value == 0:
+def _viewcone_pdf_integral(viewcone_min, viewcone_max, fov_low, fov_high):
+    scalar = np.isscalar(fov_low)
+
+    fov_low = np.atleast_1d(fov_low)
+    fov_high = np.atleast_1d(fov_high)
+
+    if (viewcone_max - viewcone_min).value == 0:
         raise ValueError("Only supported for diffuse simulations")
     else:
-        norm = 1 / (1 - np.cos(viewcone))
+        norm = 1 / (np.cos(viewcone_min) - np.cos(viewcone_max))
 
-    integral = np.cos(fov_low) - np.cos(fov_high)
+    inside = (fov_high >= viewcone_min) & (fov_low <= viewcone_max)
 
-    return norm * integral
+    integral = np.zeros(fov_low.shape)
+    lower = np.where(fov_low[inside] > viewcone_min, fov_low[inside], viewcone_min)
+    upper = np.where(fov_high[inside] < viewcone_max, fov_high[inside], viewcone_max)
+
+    integral[inside] = np.cos(lower) - np.cos(upper)
+    integral *= norm
+
+    if scalar:
+        return np.squeeze(integral)
+    return integral

--- a/pyirf/simulations.py
+++ b/pyirf/simulations.py
@@ -194,7 +194,7 @@ def _powerlaw_pdf_integral(index, e_low, e_high, e_min, e_max):
 
 
 def _viewcone_pdf_integral(viewcone_min, viewcone_max, fov_low, fov_high):
-    scalar = np.isscalar(fov_low)
+    scalar = np.asanyarray(fov_low).ndim == 0
 
     fov_low = np.atleast_1d(fov_low)
     fov_high = np.atleast_1d(fov_high)

--- a/pyirf/tests/test_simulations.py
+++ b/pyirf/tests/test_simulations.py
@@ -122,4 +122,16 @@ def test_viewcone_integral():
     expected = _viewcone_pdf_integral(vmin, vmax, 4.5 * u.deg, 5.0 * u.deg)
     assert _viewcone_pdf_integral(vmin, vmax, 4.5 * u.deg, 5.5 * u.deg) == expected
 
-    assert _viewcone_pdf_integral(vmin, vmax, 0 * u.deg, 0.5 * u.deg).ndim == 0
+    # whole region integrates to 1
+    assert _viewcone_pdf_integral(vmin, vmax, 1 * u.deg, 5 * u.deg) == 1.0 * u.one
+    assert _viewcone_pdf_integral(vmin, vmax, 0 * u.deg, 10 * u.deg) == 1.0 * u.one
+
+    vmin = np.pi * u.rad
+    vmax = 2 * np.pi * u.rad
+    np.testing.assert_allclose(
+        _viewcone_pdf_integral(vmin, vmax, np.pi * u.rad, 1.5 * np.pi * u.rad),
+        0.5
+    )
+
+    # test scalar inputs result in scalar output
+    assert _viewcone_pdf_integral(vmin, vmax, 0 * u.deg, 0.5 * u.deg).ndim == 0 * u.one

--- a/pyirf/tests/test_simulations.py
+++ b/pyirf/tests/test_simulations.py
@@ -12,7 +12,8 @@ def test_integrate_energy():
         energy_max=10 * u.TeV,
         max_impact=500 * u.m,
         spectral_index=-2,
-        viewcone=10 * u.deg,
+        viewcone_min=0 * u.deg,
+        viewcone_max=10 * u.deg,
     )
     # simplest case, no bins  outside e_min, e_max
     energy_bins = np.geomspace(info.energy_min, info.energy_max, 20)
@@ -52,7 +53,8 @@ def test_integrate_energy_fov():
         energy_max=10 * u.TeV,
         max_impact=500 * u.m,
         spectral_index=-2,
-        viewcone=10 * u.deg,
+        viewcone_min=0 * u.deg,
+        viewcone_max=10 * u.deg,
     )
 
     fov_bins = [0, 10, 20] * u.deg
@@ -70,7 +72,8 @@ def test_integrate_energy_fov():
         energy_max=10 * u.TeV,
         max_impact=500 * u.m,
         spectral_index=-2,
-        viewcone=10 * u.deg,
+        viewcone_min=0 * u.deg,
+        viewcone_max=10 * u.deg,
     )
 
     fov_bins = [0, 9, 11, 20] * u.deg
@@ -78,7 +81,7 @@ def test_integrate_energy_fov():
     n_events = info.calculate_n_showers_per_energy_and_fov(energy_bins, fov_bins)
 
     assert np.all(n_events[:, 1:2] > 0)
-    assert np.all(n_events[:, 2:] == 0)
+    np.testing.assert_equal(n_events[:, 2:], 0)
     assert np.isclose(np.sum(n_events), int(1e6))
 
 
@@ -91,7 +94,8 @@ def test_integrate_energy_fov_pointlike():
         energy_max=10 * u.TeV,
         max_impact=500 * u.m,
         spectral_index=-2,
-        viewcone=0 * u.deg,
+        viewcone_min=0 * u.deg,
+        viewcone_max=0 * u.deg,
     )
 
     fov_bins = [0, 9, 11, 20] * u.deg

--- a/pyirf/tests/test_simulations.py
+++ b/pyirf/tests/test_simulations.py
@@ -104,3 +104,22 @@ def test_integrate_energy_fov_pointlike():
     # make sure we raise an error on invalid input
     with pytest.raises(ValueError):
         info.calculate_n_showers_per_energy_and_fov(energy_bins, fov_bins)
+
+
+def test_viewcone_integral():
+    from pyirf.simulations import _viewcone_pdf_integral
+
+    vmin = 1 * u.deg
+    vmax = 5 * u.deg
+
+    # completely outside viewcone range
+    assert _viewcone_pdf_integral(vmin, vmax, 0 * u.deg, 0.5 * u.deg) == 0 * u.one
+    assert _viewcone_pdf_integral(vmin, vmax, 5.0 * u.deg, 5.5 * u.deg) == 0 * u.one
+
+    # half inside, half outside
+    expected = _viewcone_pdf_integral(vmin, vmax, 1.0 * u.deg, 1.5 * u.deg)
+    assert _viewcone_pdf_integral(vmin, vmax, 0.5 * u.deg, 1.5 * u.deg) == expected
+    expected = _viewcone_pdf_integral(vmin, vmax, 4.5 * u.deg, 5.0 * u.deg)
+    assert _viewcone_pdf_integral(vmin, vmax, 4.5 * u.deg, 5.5 * u.deg) == expected
+
+    assert _viewcone_pdf_integral(vmin, vmax, 0 * u.deg, 0.5 * u.deg).ndim == 0


### PR DESCRIPTION
To enable computing IRFs for simulations that have also a lower viewcone limit (e.g. LST ring-wobble MCs), add this missing information here.