### PR TITLE
Remove nonsensical condition from relative_sensitivity

### DIFF
--- a/docs/changes/241.bugfix.rst
+++ b/docs/changes/241.bugfix.rst
@@ -1,0 +1,4 @@
+Remove condition that relative sensitivity must be > 1.
+This condition was added by error and resulted in returning
+nan if the flux needed to fulfill the conditions is larger than
+the reference flux used to weight the events.

--- a/pyirf/sensitivity.py
+++ b/pyirf/sensitivity.py
@@ -67,10 +67,6 @@ def _relative_sensitivity(
         )
         return np.nan
 
-    # less than min_sigma
-    if relative_flux > 1:
-        return np.nan
-
     # scale to achieved flux level
     n_signal = n_signal * relative_flux
     min_excess = min_excess_over_background * n_background

--- a/pyirf/tests/test_sensitivity.py
+++ b/pyirf/tests/test_sensitivity.py
@@ -51,12 +51,13 @@ def test_calculate_sensitivity():
 
     sensitivity = calculate_sensitivity(signal_hist, bg_hist, alpha=0.2)
 
-    # too small sensitivity
+    # sensitivity smaller than 1
     signal_hist['n_weighted'] = [10, 10]
     sensitivity = calculate_sensitivity(signal_hist, bg_hist, alpha=0.2)
 
     assert len(sensitivity) == len(signal_hist)
-    assert np.all(np.isnan(sensitivity['relative_sensitivity']))
+    np.testing.assert_almost_equal(5.0, sensitivity['significance'])
+    np.testing.assert_array_less(1.0, sensitivity['relative_sensitivity'])
 
     # not above 5 percent of remaining background
     signal_hist['n_weighted'] = 699
@@ -74,6 +75,12 @@ def test_calculate_sensitivity():
     # we scale up the signal until we meet the requirement, so
     # we must have more than 5 sigma
     assert np.all(sensitivity['significance'] >= 5)
+
+    # No background at all, li&ma not applicable => event count requirement
+    signal_hist['n_weighted'] = [5, 5]
+    bg_hist['n_weighted'] = [0, 0]
+    sensitivity = calculate_sensitivity(signal_hist, bg_hist, alpha=0.2)
+    np.testing.assert_equal(sensitivity['relative_sensitivity'], 2)
 
 
 def test_estimate_background():


### PR DESCRIPTION
The function required that the relative sensitsivity (to the assumed spectrum) must be <= 1, which actually has no special meaning at all, it just means that a source brighter than the  reference spectrum is needed.

This prevented computing the sensitivity of the last two highest energy bins for North Alpha layout compared to event display.