### PR TITLE
Update python to >= 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install doc dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     - method: pip
       path: .

--- a/docs/changes/243.maintenance.rst
+++ b/docs/changes/243.maintenance.rst
@@ -1,0 +1,1 @@
+Drops python 3.8 support in accordance with `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - numpy
   - ipython
   - jupyter

--- a/pyirf/spectral.py
+++ b/pyirf/spectral.py
@@ -1,24 +1,20 @@
 """
 Functions and classes for calculating spectral weights
 """
+import sys
+from importlib.resources import as_file, files
+
 import astropy.units as u
 import numpy as np
-from scipy.interpolate import interp1d
 from astropy.table import QTable
+from scipy.interpolate import interp1d
 
 from .utils import cone_solid_angle
-import sys
-
-if sys.version_info < (3, 9):
-    from importlib_resources import files, as_file
-else:
-    from importlib.resources import files, as_file
-
 
 #: Unit of a point source flux
 #:
 #: Number of particles per Energy, time and area
-POINT_SOURCE_FLUX_UNIT = (1 / u.TeV / u.s / u.m ** 2).unit
+POINT_SOURCE_FLUX_UNIT = (1 / u.TeV / u.s / u.m**2).unit
 
 #: Unit of a diffuse flux
 #:
@@ -98,7 +94,7 @@ class PowerLaw:
     def __init__(self, normalization, index, e_ref=1 * u.TeV):
         """Create a new PowerLaw spectrum"""
         if index > 0:
-            raise ValueError(f'Index must be < 0, got {index}')
+            raise ValueError(f"Index must be < 0, got {index}")
 
         self.normalization = normalization
         self.index = index
@@ -129,13 +125,17 @@ class PowerLaw:
             solid_angle = 1
             unit = POINT_SOURCE_FLUX_UNIT
 
-        A = np.pi * simulated_event_info.max_impact ** 2
+        A = np.pi * simulated_event_info.max_impact**2
 
         delta = e_max ** (index + 1) - e_min ** (index + 1)
-        nom = (index + 1) * e_ref ** index * n_showers
+        nom = (index + 1) * e_ref**index * n_showers
         denom = (A * obstime * solid_angle) * delta
 
-        return cls(normalization=(nom / denom).to(unit), index=index, e_ref=e_ref,)
+        return cls(
+            normalization=(nom / denom).to(unit),
+            index=index,
+            e_ref=e_ref,
+        )
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.normalization} * (E / {self.e_ref})**{self.index})"
@@ -167,7 +167,6 @@ class PowerLaw:
             index=self.index,
             e_ref=self.e_ref,
         )
-
 
 
 class LogParabola:
@@ -317,7 +316,7 @@ class TableInterpolationSpectrum:
         y = self.interp(x)
 
         if self.log_flux:
-            y = 10 ** y
+            y = 10**y
 
         return u.Quantity(y, self.flux_unit, copy=False)
 
@@ -351,7 +350,9 @@ class TableInterpolationSpectrum:
 #: Aharonian et al, 2004, ApJ 614.2
 #: doi.org/10.1086/423931
 CRAB_HEGRA = PowerLaw(
-    normalization=2.83e-11 / (u.TeV * u.cm ** 2 * u.s), index=-2.62, e_ref=1 * u.TeV,
+    normalization=2.83e-11 / (u.TeV * u.cm**2 * u.s),
+    index=-2.62,
+    e_ref=1 * u.TeV,
 )
 
 #: Log-Parabola parametrization of the Crab Nebula spectrum as published by MAGIC
@@ -360,7 +361,9 @@ CRAB_HEGRA = PowerLaw(
 #: Aleksìc et al., 2015, JHEAP
 #: https://doi.org/10.1016/j.jheap.2015.01.002
 CRAB_MAGIC_JHEAP2015 = LogParabola(
-    normalization=3.23e-11 / (u.TeV * u.cm ** 2 * u.s), a=-2.47, b=-0.24,
+    normalization=3.23e-11 / (u.TeV * u.cm**2 * u.s),
+    a=-2.47,
+    b=-0.24,
 )
 
 
@@ -369,7 +372,9 @@ CRAB_MAGIC_JHEAP2015 = LogParabola(
 #: (30.2) from "The Review of Particle Physics (2020)"
 #: https://pdg.lbl.gov/2020/reviews/rpp2020-rev-cosmic-rays.pdf
 PDG_ALL_PARTICLE = PowerLaw(
-    normalization=1.8e4 / (u.GeV * u.m ** 2 * u.s * u.sr), index=-2.7, e_ref=1 * u.GeV,
+    normalization=1.8e4 / (u.GeV * u.m**2 * u.s * u.sr),
+    index=-2.7,
+    e_ref=1 * u.GeV,
 )
 
 #: Proton spectrum definition defined in the CTA Prod3b IRF Document
@@ -377,7 +382,7 @@ PDG_ALL_PARTICLE = PowerLaw(
 #: From "Description of CTA Instrument Response Functions (Production 3b Simulation)", section 4.3.1
 #: https://gitlab.cta-observatory.org/cta-consortium/aswg/documentation/internal_reports/irfs-reports/prod3b-irf-description
 IRFDOC_PROTON_SPECTRUM = PowerLaw(
-    normalization=9.8e-6 / (u.cm ** 2 * u.s * u.TeV * u.sr),
+    normalization=9.8e-6 / (u.cm**2 * u.s * u.TeV * u.sr),
     index=-2.62,
     e_ref=1 * u.TeV,
 )
@@ -387,7 +392,7 @@ IRFDOC_PROTON_SPECTRUM = PowerLaw(
 #: From "Description of CTA Instrument Response Functions (Production 3b Simulation)", section 4.3.1
 #: https://gitlab.cta-observatory.org/cta-consortium/aswg/documentation/internal_reports/irfs-reports/prod3b-irf-description
 IRFDOC_ELECTRON_SPECTRUM = PowerLawWithExponentialGaussian(
-    normalization=2.385e-9 / (u.TeV * u.cm ** 2 * u.s * u.sr),
+    normalization=2.385e-9 / (u.TeV * u.cm**2 * u.s * u.sr),
     index=-3.43,
     e_ref=1 * u.TeV,
     mu=-0.101,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,14 +20,14 @@ classifiers =
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 requires_dist = setuptools
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools_scm[toml]
 
 [flake8]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "numpy>=1.18",
         "scipy",
         "tqdm",
-        "importlib_resources ; python_version < '3.9'"
     ],
     include_package_data=True,
     extras_require=extras_require,


### PR DESCRIPTION
As mentioned by @maxnoe in #242 we could drop python 3.8 support in accordance with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).

Below: comments from #242 

@maxnoe: 
> As per NEP-29, we can also drop 3.8 now:
> 
> > On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)

@RuneDominik: 
> If we want this I'll make this a new PR, arguably we could wait for ctapipe to make this move as pyirf likely will become a dependency there sometime and we may want to aim for consistency throughout cta-observatory packages. However, even them requiring python >= 3.8 and us python >= 3.9 is ofc. solvable.