### PR TITLE
Add Extrapolator Utilizing Visible Edges Blending

### DIFF
--- a/docs/changes/253.feature.rst
+++ b/docs/changes/253.feature.rst
@@ -1,0 +1,2 @@
+Adds an extrapolator for parametrized compontents utilizing blending over visible edges, resulting 
+in a smooth extrapolation compared to the NearestSimplexExtrapolator.

--- a/docs/interpolation.rst
+++ b/docs/interpolation.rst
@@ -48,7 +48,8 @@ For parametrized components (Effective Areas and Rad-Max tables) these classes a
 =============================================    ==================  ============    ==================================================================================================
 :any:`GridDataInterpolator`                      Interpolation       Arbitrary       See also :any:`scipy.interpolate.griddata`.
 :any:`ParametrizedNearestSimplexExtrapolator`    Extrapolation       1D or 2D        Linear (1D) or baryzentric (2D) extension outside the grid's convex hull from the nearest simplex.
-:any:`ParametrizedNearestNeighborSearcher`       Nearest Neighbor    Arbitrary       Nearest neighbor finder usable instead of inter- and/or extrapolation. 
+:any:`ParametrizedVisibleEdgesExtrapolator`      Extrapolation       1D or 2D        Like :any:`ParametrizedNearestSimplexExtrapolator` but blends over all visible simplices [Alf84]_ and is thus smooth outside the convex hull.
+:any:`ParametrizedNearestNeighborSearcher`       Nearest Neighbor    Arbitrary       Nearest neighbor finder usable instead of inter- and/or extrapolation.
 =============================================    ==================  ============    ==================================================================================================
 
 For components represented by discretized PDFs (PSF and EDISP tables) these classes are:
@@ -62,6 +63,8 @@ For components represented by discretized PDFs (PSF and EDISP tables) these clas
 :any:`DiscretePDFNearestNeighborSearcher`        Nearest Neighbor    Arbitrary       Nearest neighbor finder usable instead of inter- and/or extrapolation. 
 =============================================    ==================  ============    ==============================================================================
 
+.. [Alf84] P. Alfred (1984). Triangular Extrapolation. 
+   Technical summary rept., Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
 .. [Hol+13] B. E. Hollister and A. T. Pang (2013). Interpolation of Non-Gaussian Probability Distributions for Ensemble Visualization.
     https://engineering.ucsc.edu/sites/default/files/technical-reports/UCSC-SOE-13-13.pdf
 .. [Rea99] A. L. Read (1999). Linear Interpolation of Histograms.

--- a/pyirf/interpolation/__init__.py
+++ b/pyirf/interpolation/__init__.py
@@ -34,6 +34,7 @@ from .nearest_simplex_extrapolator import (
     ParametrizedNearestSimplexExtrapolator,
 )
 from .quantile_interpolator import QuantileInterpolator
+from .visible_edges_extrapolator import ParametrizedVisibleEdgesExtrapolator
 
 __all__ = [
     "BaseComponentEstimator",
@@ -53,6 +54,7 @@ __all__ = [
     "ParametrizedInterpolator",
     "ParametrizedNearestNeighborSearcher",
     "ParametrizedNearestSimplexExtrapolator",
+    "ParametrizedVisibleEdgesExtrapolator",
     "QuantileInterpolator",
     "EffectiveAreaEstimator",
     "RadMaxEstimator",

--- a/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
+++ b/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+
+def test_find_visible_facets():
+    from pyirf.interpolation.visible_edges_extrapolator import find_visible_facets
+
+    grid = np.array([[0, 0], [20, 0], [40, 0], [10, 20], [30, 20], [10, 10]])
+
+    target1 = np.array([[0, -20]])
+    res1 = find_visible_facets(grid_points=grid, target_point=target1)
+
+    # From target1 facets spanned by grid point 0 to 1 and 1 to 2 are visible
+    assert np.all((res1 == grid[0]) | (res1 == grid[1]) | (res1 == grid[2]))
+
+    target2 = np.array([[20, 30]])
+    res2 = find_visible_facets(grid_points=grid, target_point=target2)
+
+    # From target2 only the facet spanned by grid points 4 and 5 is visible
+    assert np.all((res2 == grid[4]) | (res2 == grid[5]))
+
+    target3 = np.array([[-10, -20]])
+    res3 = find_visible_facets(grid_points=grid, target_point=target3)
+
+    # From target3 again facets spanned by grid point 0 to 1 and 1 to 2 are visible
+    assert np.all((res3 == grid[0]) | (res3 == grid[1]) | (res3 == grid[2]))
+
+    target4 = np.array([[-11, -20]])
+    res4 = find_visible_facets(grid_points=grid, target_point=target4)
+
+    # From target4 additional the facet spanned by points 0 and 3 becomes visible
+    assert np.all(
+        (res4 == grid[0]) | (res4 == grid[1]) | (res4 == grid[2]) | (res4 == grid[3])
+    )
+
+
+def test_compute_extrapolation_weights():
+    from pyirf.interpolation.visible_edges_extrapolator import (
+        compute_extrapolation_weights,
+        find_visible_facets,
+    )
+
+    grid = np.array([[0, 0], [20, 0], [40, 0], [10, 20], [30, 20], [10, 10]])
+
+    target1 = np.array([[20, 30]])
+    vis_facets1 = find_visible_facets(grid_points=grid, target_point=target1)
+    res1 = compute_extrapolation_weights(vis_facets1, target1, m=0)
+    # From target 1 only one facet is visible, thus weight should be 1
+    np.testing.assert_array_almost_equal(res1, np.array([1]))
+
+    target2 = np.array([[0, -20]])
+    # From target 2 two facets are visible, the facet spanned by points 0 and 1 under pi/4,
+    # the facet spanned by points 1 and 2 under arctan(2) - pi/4
+    vis_facets2 = find_visible_facets(grid_points=grid, target_point=target2)
+    expected_m0 = np.array([np.pi / 4, np.arctan(2) - np.pi / 4])
+    expected_m0 /= np.sum(expected_m0)
+
+    res2 = compute_extrapolation_weights(vis_facets2, target2, m=0)
+
+    np.testing.assert_array_almost_equal(res2, expected_m0)
+
+    # For m=1 angles are taken to the power of m+1=2
+    expected_m1 = np.array([np.pi / 4, np.arctan(2) - np.pi / 4]) ** 2
+    expected_m1 /= np.sum(expected_m1)
+
+    res3 = compute_extrapolation_weights(vis_facets2, target2, m=1)
+
+    np.testing.assert_array_almost_equal(res3, expected_m1)

--- a/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
+++ b/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
@@ -79,23 +79,23 @@ def test_ParametrizedVisibleEdgesExtrapolator_invalid_m():
 
     grid = np.array([[0, 0], [20, 0], [40, 0], [10, 20], [30, 20], [10, 10]])
 
-    with pytest.raises(ValueError, match="Only positiv integers allowed for m, got a."):
+    with pytest.raises(TypeError, match="Only positive integers allowed for m, got a."):
         ParametrizedVisibleEdgesExtrapolator(grid_points=grid, params=grid[:, 0], m="a")
 
     with pytest.raises(
-        ValueError, match="Only positiv integers allowed for m, got inf."
+        ValueError, match="Only positive integers allowed for m, got inf."
     ):
         ParametrizedVisibleEdgesExtrapolator(
             grid_points=grid, params=grid[:, 0], m=np.inf
         )
 
     with pytest.raises(
-        ValueError, match="Only positiv integers allowed for m, got -1."
+        ValueError, match="Only positive integers allowed for m, got -1."
     ):
         ParametrizedVisibleEdgesExtrapolator(grid_points=grid, params=grid[:, 0], m=-1)
 
     with pytest.raises(
-        ValueError, match="Only positiv integers allowed for m, got 1.2."
+        ValueError, match="Only positive integers allowed for m, got 1.2."
     ):
         ParametrizedVisibleEdgesExtrapolator(grid_points=grid, params=grid[:, 0], m=1.2)
 
@@ -150,7 +150,7 @@ def test_ParametrizedVisibleEdgesExtrapolator_2D_fallback():
 
 
 def test_ParametrizedVisibleEdgeExtrapolator_2D_grid_linear():
-    """Test wether results resembe the truth for a linear testcase"""
+    """Test whether results resemble the truth for a linear testcase"""
     from pyirf.interpolation.visible_edges_extrapolator import (
         ParametrizedVisibleEdgesExtrapolator,
     )
@@ -193,7 +193,7 @@ def test_ParametrizedVisibleEdgeExtrapolator_2D_grid_linear():
 
 
 def test_ParametrizedVisibleEdgeExtrapolator_2D_grid_smoothness():
-    """Test wether results are smooth for a non-linear testcase"""
+    """Test whether results are smooth for a non-linear testcase"""
     from pyirf.interpolation.visible_edges_extrapolator import (
         ParametrizedVisibleEdgesExtrapolator,
     )
@@ -209,7 +209,7 @@ def test_ParametrizedVisibleEdgeExtrapolator_2D_grid_smoothness():
         [
             np.array(
                 [
-                    np.dot((m.T * p + n), np.array([1, 1])) + p[0]*p[1]
+                    np.dot((m.T * p + n), np.array([1, 1])) + p[0] * p[1]
                     for m, n in zip(slope, intercept)
                 ]
             ).squeeze()

--- a/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
+++ b/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
@@ -232,4 +232,3 @@ def test_ParametrizedVisibleEdgeExtrapolator_2D_grid_smoothness():
     extrapolant_right = extrapolator(target_point_right)
 
     np.testing.assert_allclose(extrapolant_left, extrapolant_right)
-    

--- a/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
+++ b/pyirf/interpolation/tests/test_visible_edges_extrapolator.py
@@ -12,24 +12,39 @@ def test_find_visible_facets():
     res1 = find_visible_facets(grid_points=grid, target_point=target1)
 
     # From target1 facets spanned by grid point 0 to 1 and 1 to 2 are visible
+    assert res1.shape == (2, 2, 2)
+    # Check that each visible point is present in the result
+    for p in grid[[0, 1, 2]]:
+        assert np.any((res1 == p).sum(axis=-1) == 2)
+    # Check that there are no extra points
     assert np.all((res1 == grid[0]) | (res1 == grid[1]) | (res1 == grid[2]))
 
     target2 = np.array([[20, 30]])
     res2 = find_visible_facets(grid_points=grid, target_point=target2)
 
-    # From target2 only the facet spanned by grid points 4 and 5 is visible
-    assert np.all((res2 == grid[4]) | (res2 == grid[5]))
+    # From target2 only the facet spanned by grid points 3 and 4 is visible
+    assert res2.shape == (1, 2, 2)
+    for p in grid[[3, 4]]:
+        assert np.any((res2 == p).sum(axis=-1) == 2)
+    assert np.all((res2 == grid[3]) | (res2 == grid[4]))
 
+    print(res2.shape)
     target3 = np.array([[-10, -20]])
     res3 = find_visible_facets(grid_points=grid, target_point=target3)
 
     # From target3 again facets spanned by grid point 0 to 1 and 1 to 2 are visible
+    assert res3.shape == (2, 2, 2)
+    for p in grid[[0, 1, 2]]:
+        assert np.any((res3 == p).sum(axis=-1) == 2)
     assert np.all((res3 == grid[0]) | (res3 == grid[1]) | (res3 == grid[2]))
 
     target4 = np.array([[-11, -20]])
     res4 = find_visible_facets(grid_points=grid, target_point=target4)
 
     # From target4 additional the facet spanned by points 0 and 3 becomes visible
+    assert res4.shape == (3, 2, 2)
+    for p in grid[[0, 1, 2, 3]]:
+        assert np.any((res4 == p).sum(axis=-1) == 2)
     assert np.all(
         (res4 == grid[0]) | (res4 == grid[1]) | (res4 == grid[2]) | (res4 == grid[3])
     )

--- a/pyirf/interpolation/visible_edges_extrapolator.py
+++ b/pyirf/interpolation/visible_edges_extrapolator.py
@@ -97,55 +97,53 @@ class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolato
 
     While the ParametrizedNearestSimplexExtrapolator does not result in a smooth
     extrapolation outside of the grid due to using only the nearest available
-    simplex, this extrapolator blends over all visible edges.
+    simplex, this extrapolator blends over all visible edges as discussed in [1].
+    For one grid-dimension this is equal to the ParametrizedNearestSimplexExtrapolator,
+    the same holds for grids consisting of only one simplex or constellations,
+    where only one simplex is visible from a target.
+
+    Parameters
+    ----------
+    grid_points: np.ndarray, shape=(N, ...)
+        Grid points at which templates exist. May be one ot two dimensional.
+        Have to be sorted in accending order for 1D.
+    params: np.ndarray, shape=(N, ...)
+        Array of corresponding parameter values at each point in grid_points.
+        First dimesion has to correspond to number of grid_points
+    m: non-zero int >= 1
+        Degree of smoothness wanted in the extrapolation region. See [1] for
+        additional information. Defaults to 1.
+
+    Raises
+    ------
+    TypeError:
+        If m is not a number
+    ValueError:
+        If m is not a non-zero integer
+
+    Note
+    ----
+        Also calls pyirf.interpolation.ParametrizedNearestSimplexExtrapolator.__init__.
+
+    References
+    ----------
+    .. [1] P. Alfred (1984). Triangular Extrapolation. Technical summary rept.,
+    Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
+
     """
 
     def __init__(self, grid_points, params, m=1):
-        """
-        Extrapolator class blending extrapolations from all visible simplices
-        in two grid-dimensions as discussed in [1]. For one grid-dimension this
-        is equal to the ParametrizedNearestSimplexExtrapolator, the same holds
-        for grids consisting of only one simplex or constellations,
-        where only one simplex is visible from a target.
-
-        Parameters
-        ----------
-        grid_points: np.ndarray, shape=(N, ...)
-            Grid points at which templates exist. May be one ot two dimensional.
-            Have to be sorted in accending order for 1D.
-        params: np.ndarray, shape=(N, ...)
-            Array of corresponding parameter values at each point in grid_points.
-            First dimesion has to correspond to number of grid_points
-        m: non-zero int >= 1
-            Degree of smoothness wanted in the extrapolation region. See [1] for
-            additional information. Defaults to 1.
-
-        Raises
-        ------
-        ValueError:
-            If m is not a non-zero integer
-
-        Note
-        ----
-            Also calls pyirf.interpolation.ParametrizedNearestSimplexExtrapolator.__init__.
-
-        References
-        ----------
-        .. [1] P. Alfred (1984). Triangular Extrapolation. Technical summary rept.,
-        Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
-        """
-
         super().__init__(grid_points, params)
 
         # Test wether m is a number
         try:
             m > 0
         except TypeError:
-            raise ValueError(f"Only positiv integers allowed for m, got {m}.")
+            raise TypeError(f"Only positive integers allowed for m, got {m}.")
 
         # Test wether m is a finite, positive integer
         if (m <= 0) or ~np.isfinite(m) or (m != int(m)):
-            raise ValueError(f"Only positiv integers allowed for m, got {m}.")
+            raise ValueError(f"Only positive integers allowed for m, got {m}.")
 
         self.m = m
 
@@ -168,12 +166,12 @@ class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolato
 
         """
         if self.grid_dim == 1:
-            extrapolant = super().extrapolate(target_point)
+            return super().extrapolate(target_point)
         elif self.grid_dim == 2:
             visible_facet_points = find_visible_facets(self.grid_points, target_point)
 
             if visible_facet_points.shape[0] == 1:
-                extrapolant = super().extrapolate(target_point)
+                return super().extrapolate(target_point)
             else:
                 simplices_points = self.triangulation.points[
                     self.triangulation.simplices
@@ -212,4 +210,4 @@ class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolato
                     extrapolation_weigths * simplex_extrapolations, axis=0
                 )[np.newaxis, :]
 
-        return extrapolant
+                return extrapolant

--- a/pyirf/interpolation/visible_edges_extrapolator.py
+++ b/pyirf/interpolation/visible_edges_extrapolator.py
@@ -1,0 +1,162 @@
+"""
+Extrapolators for Parametrized and DiscretePDF components blending all extrapolating from 
+all visible simplices
+"""
+import numpy as np
+
+from scipy.spatial import Delaunay
+
+from .nearest_simplex_extrapolator import ParametrizedNearestSimplexExtrapolator
+from .utils import find_simplex_to_facet, point_facet_angle
+
+__all__ = ["ParametrizedVisibleEdgesExtrapolator"]
+
+
+def find_visible_facets(grid_points, target_point):
+    # Build a triangulation including the target point
+    full_set = np.vstack((grid_points, target_point))
+    triag = Delaunay(full_set)
+
+    # The target point is included in a simplex with all facets
+    # visible by it
+    simplices = triag.points[triag.simplices]
+    matches_target = np.all(simplices == target_point, axis=-1)
+    target_in_simplex = np.any(matches_target, axis=-1)
+
+    # The visible facets are spanned by those points in the matched
+    # simplices that are not the target
+    facet_point_mask = ~matches_target[target_in_simplex]
+    visible_facets = np.array(
+        [
+            triag.points[simplex[mask]]
+            for simplex, mask in zip(
+                triag.simplices[target_in_simplex], facet_point_mask
+            )
+        ]
+    )
+
+    return visible_facets
+
+
+def compute_extrapolation_weights(visible_facet_points, target_point, m):
+    angles = np.array(
+        [
+            point_facet_angle(line, target_point.squeeze())
+            for line in visible_facet_points
+        ]
+    )
+    weights = np.arccos(angles) ** (m + 1)
+
+    return weights / weights.sum()
+
+
+class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolator):
+    def __init__(self, grid_points, params, m=1):
+        """
+        Extrapolator class blending extrapolations from all visible simplices
+        in two grid-dimensions as discussed in [1]. For one grid-dimension this
+        is equal to the ParametrizedNearestSimplexExtrapolator, the same holds
+        for grids consisting of only one simplex or constellations,
+        where only one simplex is visible from a target.
+
+        Parameters
+        ----------
+        grid_points: np.ndarray, shape=(N, ...)
+            Grid points at which templates exist. May be one ot two dimensional.
+            Have to be sorted in accending order for 1D.
+        params: np.ndarray, shape=(N, ...)
+            Array of corresponding parameter values at each point in grid_points.
+            First dimesion has to correspond to number of grid_points
+        m: non-zero int >= 1
+            Degree of smoothness wanted in the extrapolation region. See [1] for
+            additional information. Defaults to 1.
+
+        Raises
+        ------
+        ValueError:
+            If m is not a non-zero integer
+
+        Note
+        ----
+            Also calls pyirf.interpolation.ParametrizedNearestSimplexExtrapolator.__init__.
+
+        References
+        ----------
+        .. [1] P. Alfred (1984). Triangular Extrapolation. Technical summary rept.,
+        Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
+        """
+
+        super().__init__(grid_points, params)
+
+        # Test wether m is a number
+        try:
+            m > 0
+        except TypeError:
+            raise ValueError(f"Only positiv integers allowed for m, got {m}.")
+
+        # Test wether m is a finite, positive integer
+        if (m <= 0) or ~np.isfinite(m) or (m != int(m)):
+            raise ValueError(f"Only positiv integers allowed for m, got {m}.")
+
+        self.m = m
+
+    def extrapolate(self, target_point):
+        """
+        Takes a grid of scalar values for a bunch of different parameters
+        and extrapolates it to given value of those parameters. Falls back
+        to ParametrizedNearestSimplexExtrapolator's behavior for 1D grids or
+        cases, where only one simplex is visible in 2D.
+
+        Parameters
+        ----------
+        target_point: numpy.ndarray
+            Value for which the extrapolation is performed (target point)
+
+        Returns
+        -------
+        values: numpy.ndarray, shape=(1,...)
+            Extrapolated values
+
+        """
+        if self.grid_dim == 1:
+            extrapolant = super().extrapolate(target_point)
+        elif self.grid_dim == 2:
+            visible_facet_points = find_visible_facets(self.grid_points, target_point)
+
+            if visible_facet_points.shape[0] == 1:
+                extrapolant = super().extrapolate(target_point)
+            else:
+                simplices_points = self.triangulation.points[
+                    self.triangulation.simplices
+                ]
+
+                visible_simplices_indices = np.array(
+                    [
+                        find_simplex_to_facet(simplices_points, facet)
+                        for facet in visible_facet_points
+                    ]
+                )
+
+                extrapolation_weigths = compute_extrapolation_weights(
+                    visible_facet_points, target_point, self.m
+                )
+
+                extrapolation_weigths = extrapolation_weigths.reshape(
+                    extrapolation_weigths.shape[0],
+                    *np.ones(self.params.ndim - 1, "int"),
+                )
+
+                simplex_extrapolations = np.array(
+                    [
+                        super()._extrapolate2D(
+                            self.triangulation.simplices[ind], target_point
+                        )
+                        for ind in visible_simplices_indices
+                    ]
+                )
+
+                extrapolant = np.sum(
+                    extrapolation_weigths * simplex_extrapolations, axis=0
+                )[np.newaxis, :]
+
+        return extrapolant

--- a/pyirf/interpolation/visible_edges_extrapolator.py
+++ b/pyirf/interpolation/visible_edges_extrapolator.py
@@ -128,7 +128,7 @@ class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolato
     References
     ----------
     .. [1] P. Alfred (1984). Triangular Extrapolation. Technical summary rept.,
-    Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
+           Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
 
     """
 

--- a/pyirf/interpolation/visible_edges_extrapolator.py
+++ b/pyirf/interpolation/visible_edges_extrapolator.py
@@ -1,6 +1,7 @@
 """
-Extrapolators for Parametrized and DiscretePDF components blending all extrapolating from 
-all visible simplices
+Extrapolators for Parametrized and DiscretePDF components that combine extrapolations 
+from all visible simplices (by blending over visible edges) to get a smooth extrapolation
+outside the grids convex hull.
 """
 import numpy as np
 from scipy.spatial import Delaunay
@@ -13,8 +14,9 @@ __all__ = ["ParametrizedVisibleEdgesExtrapolator"]
 
 def find_visible_facets(grid_points, target_point):
     """
-    Utility function to find all facets of a convex hull that are visible from
-    a point outside. To do so, this function constructs a triangulation containing
+    Find all facets of a convex hull visible from an outside point.
+    
+    To do so, this function constructs a triangulation containing
     the target point and returns all facets that span a triangulation simplex with
     it.
 
@@ -59,7 +61,7 @@ def find_visible_facets(grid_points, target_point):
 
 def compute_extrapolation_weights(visible_facet_points, target_point, m):
     """
-    Utility function to compute extrapolation weight according to [1].
+    Compute extrapolation weight according to [1].
 
     Parameters
     ----------
@@ -93,7 +95,7 @@ def compute_extrapolation_weights(visible_facet_points, target_point, m):
 
 class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolator):
     """
-    Extrapolator class extending the ParametrizedNearestSimplexExtrapolator.
+    Extrapolator using blending over visible edges.
 
     While the ParametrizedNearestSimplexExtrapolator does not result in a smooth
     extrapolation outside of the grid due to using only the nearest available
@@ -148,23 +150,6 @@ class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolato
         self.m = m
 
     def extrapolate(self, target_point):
-        """
-        Takes a grid of scalar values for a bunch of different parameters
-        and extrapolates it to given value of those parameters. Falls back
-        to ParametrizedNearestSimplexExtrapolator's behavior for 1D grids or
-        cases, where only one simplex is visible in 2D.
-
-        Parameters
-        ----------
-        target_point: numpy.ndarray
-            Value for which the extrapolation is performed (target point)
-
-        Returns
-        -------
-        values: numpy.ndarray, shape=(1,...)
-            Extrapolated values
-
-        """
         if self.grid_dim == 1:
             return super().extrapolate(target_point)
         elif self.grid_dim == 2:

--- a/pyirf/interpolation/visible_edges_extrapolator.py
+++ b/pyirf/interpolation/visible_edges_extrapolator.py
@@ -14,9 +14,9 @@ __all__ = ["ParametrizedVisibleEdgesExtrapolator"]
 def find_visible_facets(grid_points, target_point):
     """
     Utility function to find all facets of a convex hull that are visible from
-    a point outside. To do so, this function constructs a trinangulation containing
-    the target point and returns all facets that span a trinangulation simplex with
-    the it.
+    a point outside. To do so, this function constructs a triangulation containing
+    the target point and returns all facets that span a triangulation simplex with
+    it.
 
     Parameters
     ----------
@@ -92,6 +92,14 @@ def compute_extrapolation_weights(visible_facet_points, target_point, m):
 
 
 class ParametrizedVisibleEdgesExtrapolator(ParametrizedNearestSimplexExtrapolator):
+    """
+    Extrapolator class extending the ParametrizedNearestSimplexExtrapolator.
+
+    While the ParametrizedNearestSimplexExtrapolator does not result in a smooth
+    extrapolation outside of the grid due to using only the nearest available
+    simplex, this extrapolator blends over all visible edges.
+    """
+
     def __init__(self, grid_points, params, m=1):
         """
         Extrapolator class blending extrapolations from all visible simplices


### PR DESCRIPTION
The current `ParametrizedNearestSimplexExtrapolator`, while requiring minimal assumptions, does not result in a smooth extrapolation. Discontinuous results occur where the nearest simplex changes from one to another and with it the used templates. Blending over visible edges [1] solves this but ofc. introduces further assumptions.

[1]  P. Alfred (1984). Triangular Extrapolation. Technical summary rept., Univ. of Wisconsin-Madison. https://apps.dtic.mil/sti/pdfs/ADA144660.pdf
