### PR TITLE
Update energy_dispersion_to_migration to account for fix in energy dispersion normalization

### DIFF
--- a/docs/changes/273.bugfix.rst
+++ b/docs/changes/273.bugfix.rst
@@ -1,0 +1,4 @@
+Fix ``pyirf.irfs.energy_dispersion.energy_dispersion_to_migration``.
+This function was not adapted to the now correct normalization of the
+energy dispersion matrix, resulting in wrong results on the now correct
+matrices.

--- a/pyirf/irf/energy_dispersion.py
+++ b/pyirf/irf/energy_dispersion.py
@@ -103,8 +103,8 @@ def energy_migration_matrix(
     Returns
     -------
     matrix : array-like
-        Migration matrix as probabilities along the true
-        energy acis with shape
+        Migration matrix as probabilities along the reconstructed energy axis.
+        energy axis with shape
         (n_true_energy_bins, n_reco_energy_bins, n_fov_offset_bins)
         containing energies in TeV.
     """

--- a/pyirf/irf/tests/test_energy_dispersion.py
+++ b/pyirf/irf/tests/test_energy_dispersion.py
@@ -143,7 +143,7 @@ def test_energy_dispersion_to_migration():
     assert migration_matrix.shape[2] == dispersion_matrix.shape[2]
 
     # test that all migrations are included for central energies
-    np.allclose(migration_matrix.sum(axis=1).max(), 1, rtol=0.1)
+    assert np.isclose(migration_matrix.sum(axis=1).max(), 1, rtol=0.01)
 
     # test that migrations dont always sum to 1 (since some energies are
     # not included in the matrix)

--- a/pyirf/irf/tests/test_energy_dispersion.py
+++ b/pyirf/irf/tests/test_energy_dispersion.py
@@ -64,17 +64,29 @@ def test_energy_dispersion():
 
     assert np.isclose(
         TRUE_SIGMA_1,
-        0.5 * (ppf(cdf[0, :, 0], migration_bins, 0.84) - ppf(cdf[0, :, 0], migration_bins, 0.16)),
+        0.5
+        * (
+            ppf(cdf[0, :, 0], migration_bins, 0.84)
+            - ppf(cdf[0, :, 0], migration_bins, 0.16)
+        ),
         rtol=0.1,
     )
     assert np.isclose(
         TRUE_SIGMA_2,
-        0.5 * (ppf(cdf[1, :, 0], migration_bins, 0.84) - ppf(cdf[1, :, 0], migration_bins, 0.16)),
+        0.5
+        * (
+            ppf(cdf[1, :, 0], migration_bins, 0.84)
+            - ppf(cdf[1, :, 0], migration_bins, 0.16)
+        ),
         rtol=0.1,
     )
     assert np.isclose(
         TRUE_SIGMA_3,
-        0.5 * (ppf(cdf[2, :, 0], migration_bins, 0.84) - ppf(cdf[2, :, 0], migration_bins, 0.16)),
+        0.5
+        * (
+            ppf(cdf[2, :, 0], migration_bins, 0.84)
+            - ppf(cdf[2, :, 0], migration_bins, 0.16)
+        ),
         rtol=0.1,
     )
 
@@ -85,16 +97,15 @@ def test_energy_dispersion_to_migration():
 
     np.random.seed(0)
     N = 10000
-    true_energy_bins = 10**np.arange(np.log10(0.2), np.log10(200), 1/10) * u.TeV
+    true_energy_bins = 10 ** np.arange(np.log10(0.2), np.log10(200), 1 / 10) * u.TeV
 
     fov_offset_bins = np.array([0, 1, 2]) * u.deg
     migration_bins = np.linspace(0, 2, 101)
 
-    true_energy = np.random.uniform(
-        true_energy_bins[0].value,
-        true_energy_bins[-1].value,
-        size=N
-    ) * u.TeV
+    true_energy = (
+        np.random.uniform(true_energy_bins[0].value, true_energy_bins[-1].value, size=N)
+        * u.TeV
+    )
     reco_energy = true_energy * np.random.uniform(0.5, 1.5, size=N)
 
     selected_events = QTable(
@@ -116,15 +127,14 @@ def test_energy_dispersion_to_migration():
     )
 
     # migration matrix selecting a limited energy band with different binsizes
-    new_true_energy_bins = 10**np.arange(np.log10(2), np.log10(20), 1/5) * u.TeV
-    new_reco_energy_bins = 10**np.arange(np.log10(2), np.log10(20), 1/5) * u.TeV
+    new_true_energy_bins = 10 ** np.arange(np.log10(2), np.log10(20), 1 / 5) * u.TeV
+    new_reco_energy_bins = 10 ** np.arange(np.log10(2), np.log10(20), 1 / 5) * u.TeV
     migration_matrix = energy_dispersion_to_migration(
         dispersion_matrix,
         true_energy_bins,
         migration_bins,
         new_true_energy_bins,
         new_reco_energy_bins,
-
     )
 
     # test dimension
@@ -133,12 +143,55 @@ def test_energy_dispersion_to_migration():
     assert migration_matrix.shape[2] == dispersion_matrix.shape[2]
 
     # test that all migrations are included for central energies
-    assert np.isclose(migration_matrix.sum(axis=1).max(), 1, rtol=0.01)
+    np.allclose(migration_matrix.sum(axis=1).max(), 1, rtol=0.1)
 
     # test that migrations dont always sum to 1 (since some energies are
     # not included in the matrix)
-    assert migration_matrix.sum() < (len(new_true_energy_bins) - 1) * (len(fov_offset_bins) - 1)
+    assert migration_matrix.sum() < (len(new_true_energy_bins) - 1) * (
+        len(fov_offset_bins) - 1
+    )
     assert np.all(np.isfinite(migration_matrix))
+
+
+def test_energy_migration_matrix_from_events():
+    from pyirf.irf.energy_dispersion import energy_migration_matrix
+
+    np.random.seed(0)
+    N = 10000
+    true_energy_bins = 10 ** np.arange(np.log10(0.2), np.log10(200), 1 / 10) * u.TeV
+    reco_energy_bins = 10 ** np.arange(np.log10(2), np.log10(20), 1 / 5) * u.TeV
+    fov_offset_bins = np.array([0, 1, 2]) * u.deg
+
+    true_energy = (
+        np.random.uniform(true_energy_bins[0].value, true_energy_bins[-1].value, size=N)
+        * u.TeV
+    )
+    reco_energy = true_energy * np.random.uniform(0.5, 1.5, size=N)
+
+    events = QTable(
+        {
+            "reco_energy": reco_energy,
+            "true_energy": true_energy,
+            "true_source_fov_offset": np.concatenate(
+                [
+                    np.full(N // 2, 0.2),
+                    np.full(N // 2, 1.5),
+                ]
+            )
+            * u.deg,
+        }
+    )
+
+    matrix = energy_migration_matrix(
+        events, true_energy_bins, reco_energy_bins, fov_offset_bins
+    )
+
+    assert matrix.shape == (
+        len(true_energy_bins) - 1,
+        len(reco_energy_bins) - 1,
+        len(fov_offset_bins) - 1,
+    )
+    assert np.allclose(matrix.sum(axis=1).max(), 1, rtol=0.1)
 
 
 def test_overflow_bins_migration_matrix():
@@ -150,21 +203,24 @@ def test_overflow_bins_migration_matrix():
     N = 10000
 
     # add under/overflow bins
-    bins = 10 ** np.arange(
-        np.log10(0.2),
-        np.log10(200),
-        1 / 10,
-    ) * u.TeV
+    bins = (
+        10
+        ** np.arange(
+            np.log10(0.2),
+            np.log10(200),
+            1 / 10,
+        )
+        * u.TeV
+    )
     true_energy_bins = add_overflow_bins(bins, positive=False)
 
     fov_offset_bins = np.array([0, 1, 2]) * u.deg
     migration_bins = np.linspace(0, 2, 101)
 
-    true_energy = np.random.uniform(
-        true_energy_bins[1].value,
-        true_energy_bins[-2].value,
-        size=N
-    ) * u.TeV
+    true_energy = (
+        np.random.uniform(true_energy_bins[1].value, true_energy_bins[-2].value, size=N)
+        * u.TeV
+    )
     reco_energy = true_energy * np.random.uniform(0.5, 1.5, size=N)
 
     selected_events = QTable(


### PR DESCRIPTION
This attempts to update the function that produces the energy migration matrix from the energy dispersion.

After #250 this function was not updated which resulted in the wrong matrix when compared with the one computed starting directly from the events (see #272)

I think I got a working result, but it might still be wrong - also for reasons related to my use case I didn't test this using different binning, so I am re-sampling the same thing to comparing with the original matrix (left panel)

![image](https://github.com/cta-observatory/pyirf/assets/17836610/e08b83eb-fb92-47ea-9228-04364788213f)

I should also update the unit test in order to compare the counts, but since it comes from a re-sampling I am not sure how much big the relative difference should be.