### PR TITLE
Add cref

### DIFF
--- a/docs/changes/275.maintenance.rst
+++ b/docs/changes/275.maintenance.rst
@@ -1,0 +1,1 @@
+Added filling of CREF keyword (IRF axis order) in the output files

--- a/pyirf/io/gadf.py
+++ b/pyirf/io/gadf.py
@@ -76,7 +76,8 @@ def create_aeff2d_hdu(
     header["HDUCLAS3"] = "POINT-LIKE" if point_like else "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "AEFF_2D"
     header["DATE"] = Time.now().utc.iso
-    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
+    idx = aeff.colnames.index("EFFAREA") + 1
+    header[f"CREF{idx}"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(aeff, header=header, name=extname)
@@ -134,7 +135,8 @@ def create_psf_table_hdu(
     header["HDUCLAS3"] = "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "PSF_TABLE"
     header["DATE"] = Time.now().utc.iso
-    header["CREF7"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI,RAD_LO:RAD_HI)"
+    idx = psf_.colnames.index("RPSF") + 1
+    header[f"CREF{idx}"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI,RAD_LO:RAD_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(psf_, header=header, name=extname)
@@ -193,7 +195,8 @@ def create_energy_dispersion_hdu(
     header["HDUCLAS3"] = "POINT-LIKE" if point_like else "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "EDISP_2D"
     header["DATE"] = Time.now().utc.iso
-    header["CREF7"] = "(ENERG_LO:ENERG_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)"
+    idx = edisp.colnames.index("MATRIX") + 1
+    header[f"CREF{idx}"] = "(ENERG_LO:ENERG_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(edisp, header=header, name=extname)
@@ -250,7 +253,8 @@ def create_background_2d_hdu(
     header["HDUCLAS3"] = "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "BKG_2D"
     header["DATE"] = Time.now().utc.iso
-    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
+    idx = bkg.colnames.index("BKG") + 1
+    header[f"CREF{idx}"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(bkg, header=header, name=extname)
@@ -304,7 +308,8 @@ def create_rad_max_hdu(
     header["HDUCLAS3"] = "POINT-LIKE"
     header["HDUCLAS4"] = "RAD_MAX_2D"
     header["DATE"] = Time.now().utc.iso
-    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
+    idx = rad_max_table.colnames.index("RAD_MAX") + 1
+    header[f"CREF{idx}"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(rad_max_table, header=header, name=extname)

--- a/pyirf/io/gadf.py
+++ b/pyirf/io/gadf.py
@@ -76,6 +76,7 @@ def create_aeff2d_hdu(
     header["HDUCLAS3"] = "POINT-LIKE" if point_like else "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "AEFF_2D"
     header["DATE"] = Time.now().utc.iso
+    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(aeff, header=header, name=extname)
@@ -133,6 +134,7 @@ def create_psf_table_hdu(
     header["HDUCLAS3"] = "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "PSF_TABLE"
     header["DATE"] = Time.now().utc.iso
+    header["CREF7"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI,RAD_LO:RAD_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(psf_, header=header, name=extname)
@@ -191,6 +193,7 @@ def create_energy_dispersion_hdu(
     header["HDUCLAS3"] = "POINT-LIKE" if point_like else "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "EDISP_2D"
     header["DATE"] = Time.now().utc.iso
+    header["CREF7"] = "(ENERG_LO:ENERG_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(edisp, header=header, name=extname)
@@ -247,6 +250,7 @@ def create_background_2d_hdu(
     header["HDUCLAS3"] = "FULL-ENCLOSURE"
     header["HDUCLAS4"] = "BKG_2D"
     header["DATE"] = Time.now().utc.iso
+    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(bkg, header=header, name=extname)
@@ -300,6 +304,7 @@ def create_rad_max_hdu(
     header["HDUCLAS3"] = "POINT-LIKE"
     header["HDUCLAS4"] = "RAD_MAX_2D"
     header["DATE"] = Time.now().utc.iso
+    header["CREF5"] = "(ENERG_LO:ENERG_HI,THETA_LO:THETA_HI)"
     _add_header_cards(header, **header_cards)
 
     return BinTableHDU(rad_max_table, header=header, name=extname)

--- a/pyirf/io/tests/test_gadf.py
+++ b/pyirf/io/tests/test_gadf.py
@@ -196,7 +196,6 @@ def test_cref(aeff2d_hdus, edisp_hdus, psf_hdu, bg_hdu, rad_max_hdu):
             fits.HDUList(hdus).writeto(f.name)
             readhdul = fits.open(f.name)
             for hdu in readhdul[1:]: # skip Primary
-                #print(hdu.header['EXTNAME'])
                 names=hdu.data.columns.names
                 # the IRF is always in the last column
                 cref = hdu.header['CREF'+str(len(names))]
@@ -204,7 +203,6 @@ def test_cref(aeff2d_hdus, edisp_hdus, psf_hdu, bg_hdu, rad_max_hdu):
                 cref = cref[1:-1].split(',')
                 # transposed due to different fits and numpy axis order
                 readshape=hdu.data[names[-1]].T.shape
-                #print(cref, readshape)
                 # only one set of IRFs saved per test file
                 assert readshape[-1] == 1, "first axis size is not 1"
 


### PR DESCRIPTION
I found in GDAF specification:
https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/irf_axes/index.html
(see also the example in https://gamma-astro-data-formats.readthedocs.io/en/latest/general/fits-arrays.html#id1)
that the axis order of IRFs is not fully fixed, but only recommended, and that the tools using the IRFS should read it from CREF header key, which so far was not filled in GDAF I/O classes of pyirf.
I added it for all the IRFs in gadf.py file, and added a test function to validate that all the shapes are consistent