### PR TITLE
Fix scipy to <1.12

### DIFF
--- a/docs/changes/279.maintenance.rst
+++ b/docs/changes/279.maintenance.rst
@@ -1,0 +1,1 @@
+Temporarily fix scipy to <1.12 until gammapy supports API changes introduced with scipy 1.12.

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ipython
   - jupyter
   - matplotlib
-  - scipy
+  - scipy<1.12
   - astropy=5
   - setuptools
   - tqdm

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "astropy>=5.3,<7.0.0a0",
         "numpy>=1.21",
-        "scipy",
+        "scipy<1.12",
         "tqdm",
     ],
     include_package_data=True,


### PR DESCRIPTION
With the recent release of `scipy 1.12.0` the API of `scipy.optimize.RootResults` seems to have changed in a way `gammapy` does not yet provide. Fixing scipy to 1.11.4 should offer a temporary workaround.
