### PR TITLE
Add support for 3D PSF table IRFs

### DIFF
--- a/pyirf/io/__init__.py
+++ b/pyirf/io/__init__.py
@@ -3,6 +3,8 @@ from .gadf import (
     create_aeff2d_hdu,
     create_energy_dispersion_hdu,
     create_psf_table_hdu,
+    create_psf_table_asymmetric_polar_hdu,
+    create_psf_table_asymmetric_lonlat_hdu,
     create_rad_max_hdu,
     create_background_2d_hdu,
 )
@@ -14,6 +16,8 @@ __all__ = [
     "create_aeff2d_hdu",
     "create_energy_dispersion_hdu",
     "create_psf_table_hdu",
+    "create_psf_table_asymmetric_polar_hdu",
+    "create_psf_table_asymmetric_lonlat_hdu",
     "create_rad_max_hdu",
     "create_background_2d_hdu",
 ]

--- a/pyirf/io/__init__.py
+++ b/pyirf/io/__init__.py
@@ -3,8 +3,8 @@ from .gadf import (
     create_aeff2d_hdu,
     create_energy_dispersion_hdu,
     create_psf_table_hdu,
-    create_psf_table_asymmetric_polar_hdu,
-    create_psf_table_asymmetric_lonlat_hdu,
+    create_psf_table_3d_polar_hdu,
+    create_psf_table_3d_lonlat_hdu,
     create_rad_max_hdu,
     create_background_2d_hdu,
 )
@@ -16,8 +16,8 @@ __all__ = [
     "create_aeff2d_hdu",
     "create_energy_dispersion_hdu",
     "create_psf_table_hdu",
-    "create_psf_table_asymmetric_polar_hdu",
-    "create_psf_table_asymmetric_lonlat_hdu",
+    "create_psf_table_3d_polar_hdu",
+    "create_psf_table_3d_lonlat_hdu",
     "create_rad_max_hdu",
     "create_background_2d_hdu",
 ]

--- a/pyirf/io/gadf.py
+++ b/pyirf/io/gadf.py
@@ -13,6 +13,8 @@ __all__ = [
     "create_energy_dispersion_hdu",
     "create_psf_table_hdu",
     "create_rad_max_hdu",
+    "create_psf_table_3d_polar_hdu",
+    "create_psf_table_3d_lonlat_hdu"
 ]
 
 
@@ -142,7 +144,7 @@ def create_psf_table_hdu(
     return BinTableHDU(psf_, header=header, name=extname)
 
 
-def create_psf_table_asymmetric_polar_hdu(
+def create_psf_table_3d_polar_hdu(
     psf,
     true_energy_bins,
     source_offset_bins,
@@ -200,7 +202,7 @@ def create_psf_table_asymmetric_polar_hdu(
     return BinTableHDU(psf_, header=header, name=extname)
 
 
-def create_psf_table_asymmetric_lonlat_hdu(
+def create_psf_table_3d_lonlat_hdu(
     psf,
     true_energy_bins,
     source_offset_bins,

--- a/pyirf/irf/__init__.py
+++ b/pyirf/irf/__init__.py
@@ -8,8 +8,8 @@ from .effective_area import (
 from .energy_dispersion import energy_dispersion
 from .psf import (
     psf_table,
-    psf_table_asymmetric_polar,
-    psf_table_asymmetric_lonlat,
+    psf_table_3d_polar,
+    psf_table_3d_lonlat,
 )
 from .background import background_2d
 
@@ -21,7 +21,7 @@ __all__ = [
     "effective_area_3d_lonlat",
     "energy_dispersion",
     "psf_table",
-    "psf_table_asymmetric_polar",
-    "psf_table_asymmetric_lonlat",
+    "psf_table_3d_polar",
+    "psf_table_3d_lonlat",
     "background_2d",
 ]

--- a/pyirf/irf/__init__.py
+++ b/pyirf/irf/__init__.py
@@ -6,7 +6,11 @@ from .effective_area import (
     effective_area_3d_lonlat,
 )
 from .energy_dispersion import energy_dispersion
-from .psf import psf_table
+from .psf import (
+    psf_table,
+    psf_table_asymmetric_polar,
+    psf_table_asymmetric_lonlat,
+)
 from .background import background_2d
 
 __all__ = [
@@ -17,5 +21,7 @@ __all__ = [
     "effective_area_3d_lonlat",
     "energy_dispersion",
     "psf_table",
+    "psf_table_asymmetric_polar",
+    "psf_table_asymmetric_lonlat",
     "background_2d",
 ]

--- a/pyirf/irf/psf.py
+++ b/pyirf/irf/psf.py
@@ -30,7 +30,7 @@ def psf_table(events, true_energy_bins, source_offset_bins, fov_offset_bins):
     return psf
 
 
-def psf_table_asymmetric_polar(
+def psf_table_3d_polar(
     events,
     true_energy_bins,
     source_offset_bins,
@@ -38,7 +38,7 @@ def psf_table_asymmetric_polar(
     fov_position_angle_bins,
 ):
     """
-    Calculate the table based PSF (radially symmetrical bins around the true source, asymmetric polar bins in the FoV)
+    Calculate the table based PSF (radially symmetrical bins around the true source, offset and position angle bins in the FoV)
     """
 
     array = np.column_stack(
@@ -64,7 +64,7 @@ def psf_table_asymmetric_polar(
     return psf
 
 
-def psf_table_asymmetric_lonlat(
+def psf_table_3d_lonlat(
     events,
     true_energy_bins,
     source_offset_bins,
@@ -72,7 +72,7 @@ def psf_table_asymmetric_lonlat(
     fov_lat_bins,
 ):
     """
-    Calculate the table based PSF (radially symmetrical bins around the true source, asymmetric lon/lat bins in the FoV)
+    Calculate the table based PSF (radially symmetrical bins around the true source, lon/lat bins in the FoV)
     """
 
     array = np.column_stack(

--- a/pyirf/irf/psf.py
+++ b/pyirf/irf/psf.py
@@ -30,6 +30,74 @@ def psf_table(events, true_energy_bins, source_offset_bins, fov_offset_bins):
     return psf
 
 
+def psf_table_asymmetric_polar(
+    events,
+    true_energy_bins,
+    source_offset_bins,
+    fov_offset_bins,
+    fov_position_angle_bins,
+):
+    """
+    Calculate the table based PSF (radially symmetrical bins around the true source, asymmetric polar bins in the FoV)
+    """
+
+    array = np.column_stack(
+        [
+            events["true_energy"].to_value(u.TeV),
+            events["true_source_fov_offset"].to_value(u.deg),
+            events["true_source_fov_position_angle"].to_value(u.deg),
+            events["theta"].to_value(u.deg),
+        ]
+    )
+
+    hist, _ = np.histogramdd(
+        array,
+        [
+            true_energy_bins.to_value(u.TeV),
+            fov_offset_bins.to_value(u.deg),
+            fov_position_angle_bins.to_value(u.deg),
+            source_offset_bins.to_value(u.deg),
+        ],
+    )
+
+    psf = _normalize_psf(hist, source_offset_bins)
+    return psf
+
+
+def psf_table_asymmetric_lonlat(
+    events,
+    true_energy_bins,
+    source_offset_bins,
+    fov_lon_bins,
+    fov_lat_bins,
+):
+    """
+    Calculate the table based PSF (radially symmetrical bins around the true source, asymmetric lon/lat bins in the FoV)
+    """
+
+    array = np.column_stack(
+        [
+            events["true_energy"].to_value(u.TeV),
+            events["true_source_fov_lon"].to_value(u.deg),
+            events["true_source_fov_lat"].to_value(u.deg),
+            events["theta"].to_value(u.deg),
+        ]
+    )
+
+    hist, _ = np.histogramdd(
+        array,
+        [
+            true_energy_bins.to_value(u.TeV),
+            fov_lon_bins.to_value(u.deg),
+            fov_lat_bins.to_value(u.deg),
+            source_offset_bins.to_value(u.deg),
+        ],
+    )
+
+    psf = _normalize_psf(hist, source_offset_bins)
+    return psf
+
+
 def _normalize_psf(hist, source_offset_bins):
     """Normalize the psf histogram to a probability densitity over solid angle"""
     solid_angle = np.diff(cone_solid_angle(source_offset_bins))
@@ -38,8 +106,8 @@ def _normalize_psf(hist, source_offset_bins):
     with np.errstate(invalid="ignore"):
 
         # normalize over the theta axis
-        n_events = hist.sum(axis=2)
+        n_events = hist.sum(axis=-1)
         # normalize and replace nans with 0
-        psf = np.nan_to_num(hist / n_events[:, :, np.newaxis])
+        psf = np.nan_to_num(hist / n_events[..., np.newaxis])
 
     return psf / solid_angle

--- a/pyirf/irf/tests/test_psf.py
+++ b/pyirf/irf/tests/test_psf.py
@@ -87,7 +87,9 @@ def test_psf_asymmetric_polar():
     source_bins = np.linspace(0, 1, 201) * u.deg
 
     # We return a table with one row as needed for gadf
-    psf = psf_table_asymmetric_polar(events, energy_bins, source_bins, fov_bins_theta, fov_bins_phi)
+    psf = psf_table_asymmetric_polar(
+        events, energy_bins, source_bins, fov_bins_theta, fov_bins_phi
+    )
 
     # 2 energy bins, 1 fov bin, 200 source distance bins
     assert psf.shape == (2, 1, 1, 200)
@@ -144,7 +146,9 @@ def test_psf_asymmetric_lonlat():
     source_bins = np.linspace(0, 1, 201) * u.deg
 
     # We return a table with one row as needed for gadf
-    psf = psf_table_asymmetric_lonlat(events, energy_bins, source_bins, fov_bins, fov_bins)
+    psf = psf_table_asymmetric_lonlat(
+        events, energy_bins, source_bins, fov_bins, fov_bins
+    )
 
     # 2 energy bins, 1 fov bin, 200 source distance bins
     assert psf.shape == (2, 1, 1, 200)

--- a/pyirf/irf/tests/test_psf.py
+++ b/pyirf/irf/tests/test_psf.py
@@ -58,8 +58,8 @@ def test_psf():
     )
 
 
-def test_psf_asymmetric_polar():
-    from pyirf.irf import psf_table_asymmetric_polar
+def test_psf_3d_polar():
+    from pyirf.irf import psf_table_3d_polar
     from pyirf.utils import cone_solid_angle
 
     np.random.seed(0)
@@ -87,7 +87,7 @@ def test_psf_asymmetric_polar():
     source_bins = np.linspace(0, 1, 201) * u.deg
 
     # We return a table with one row as needed for gadf
-    psf = psf_table_asymmetric_polar(
+    psf = psf_table_3d_polar(
         events, energy_bins, source_bins, fov_bins_theta, fov_bins_phi
     )
 
@@ -118,8 +118,8 @@ def test_psf_asymmetric_polar():
     )
 
 
-def test_psf_asymmetric_lonlat():
-    from pyirf.irf import psf_table_asymmetric_lonlat
+def test_psf_3d_lonlat():
+    from pyirf.irf import psf_table_3d_lonlat
     from pyirf.utils import cone_solid_angle
 
     np.random.seed(0)
@@ -146,7 +146,7 @@ def test_psf_asymmetric_lonlat():
     source_bins = np.linspace(0, 1, 201) * u.deg
 
     # We return a table with one row as needed for gadf
-    psf = psf_table_asymmetric_lonlat(
+    psf = psf_table_3d_lonlat(
         events, energy_bins, source_bins, fov_bins, fov_bins
     )
 

--- a/pyirf/irf/tests/test_psf.py
+++ b/pyirf/irf/tests/test_psf.py
@@ -56,3 +56,118 @@ def test_psf():
         TRUE_SIGMA_2 * u.deg,
         rtol=0.1,
     )
+
+
+def test_psf_asymmetric_polar():
+    from pyirf.irf import psf_table_asymmetric_polar
+    from pyirf.utils import cone_solid_angle
+
+    np.random.seed(0)
+
+    N = 1000
+
+    TRUE_SIGMA_1 = 0.2
+    TRUE_SIGMA_2 = 0.1
+    TRUE_SIGMA = np.append(np.full(N, TRUE_SIGMA_1), np.full(N, TRUE_SIGMA_2))
+
+    # toy event data set with just two energies
+    # and a psf per energy bin, point-like
+    events = QTable(
+        {
+            "true_energy": np.append(np.full(N, 1), np.full(N, 2)) * u.TeV,
+            "true_source_fov_offset": np.zeros(2 * N) * u.deg,
+            "true_source_fov_position_angle": np.zeros(2 * N) * u.deg,
+            "theta": np.random.normal(0, TRUE_SIGMA) * u.deg,
+        }
+    )
+
+    energy_bins = [0, 1.5, 3] * u.TeV
+    fov_bins_theta = [0, 1] * u.deg
+    fov_bins_phi = [0, 360] * u.deg
+    source_bins = np.linspace(0, 1, 201) * u.deg
+
+    # We return a table with one row as needed for gadf
+    psf = psf_table_asymmetric_polar(events, energy_bins, source_bins, fov_bins_theta, fov_bins_phi)
+
+    # 2 energy bins, 1 fov bin, 200 source distance bins
+    assert psf.shape == (2, 1, 1, 200)
+    assert psf.unit == u.Unit("sr-1")
+
+    # check that psf is normalized
+    bin_solid_angle = np.diff(cone_solid_angle(source_bins))
+
+    assert np.allclose(np.sum(psf * bin_solid_angle, axis=3), 1.0)
+
+    cumulated = np.cumsum(psf * bin_solid_angle, axis=3)
+
+    # first energy and only fov bin
+    bin_centers = 0.5 * (source_bins[1:] + source_bins[:-1])
+    assert u.isclose(
+        bin_centers[np.where(cumulated[0, 0, 0, :] >= 0.68)[0][0]],
+        TRUE_SIGMA_1 * u.deg,
+        rtol=0.1,
+    )
+
+    # second energy and only fov bin
+    assert u.isclose(
+        bin_centers[np.where(cumulated[1, 0, 0, :] >= 0.68)[0][0]],
+        TRUE_SIGMA_2 * u.deg,
+        rtol=0.1,
+    )
+
+
+def test_psf_asymmetric_lonlat():
+    from pyirf.irf import psf_table_asymmetric_lonlat
+    from pyirf.utils import cone_solid_angle
+
+    np.random.seed(0)
+
+    N = 1000
+
+    TRUE_SIGMA_1 = 0.2
+    TRUE_SIGMA_2 = 0.1
+    TRUE_SIGMA = np.append(np.full(N, TRUE_SIGMA_1), np.full(N, TRUE_SIGMA_2))
+
+    # toy event data set with just two energies
+    # and a psf per energy bin, point-like
+    events = QTable(
+        {
+            "true_energy": np.append(np.full(N, 1), np.full(N, 2)) * u.TeV,
+            "true_source_fov_lon": np.zeros(2 * N) * u.deg,
+            "true_source_fov_lat": np.zeros(2 * N) * u.deg,
+            "theta": np.random.normal(0, TRUE_SIGMA) * u.deg,
+        }
+    )
+
+    energy_bins = [0, 1.5, 3] * u.TeV
+    fov_bins = [-1, 1] * u.deg
+    source_bins = np.linspace(0, 1, 201) * u.deg
+
+    # We return a table with one row as needed for gadf
+    psf = psf_table_asymmetric_lonlat(events, energy_bins, source_bins, fov_bins, fov_bins)
+
+    # 2 energy bins, 1 fov bin, 200 source distance bins
+    assert psf.shape == (2, 1, 1, 200)
+    assert psf.unit == u.Unit("sr-1")
+
+    # check that psf is normalized
+    bin_solid_angle = np.diff(cone_solid_angle(source_bins))
+
+    assert np.allclose(np.sum(psf * bin_solid_angle, axis=3), 1.0)
+
+    cumulated = np.cumsum(psf * bin_solid_angle, axis=3)
+
+    # first energy and only fov bin
+    bin_centers = 0.5 * (source_bins[1:] + source_bins[:-1])
+    assert u.isclose(
+        bin_centers[np.where(cumulated[0, 0, 0, :] >= 0.68)[0][0]],
+        TRUE_SIGMA_1 * u.deg,
+        rtol=0.1,
+    )
+
+    # second energy and only fov bin
+    assert u.isclose(
+        bin_centers[np.where(cumulated[1, 0, 0, :] >= 0.68)[0][0]],
+        TRUE_SIGMA_2 * u.deg,
+        rtol=0.1,
+    )


### PR DESCRIPTION
Introduces the `psf_table_3d_polar` and `psf_table_3d_lonlat` functions to `pyirf.irf.psf`.
These calculate the PSF in energy, source offset, and two FoV axes, allowing accounting for asymmetry of the PSF in the FoV.

The relevant functions to create FITS binary tables in the GADF format have also been added to `pyirf.io.gadf`.