### PR TITLE
Fix gammapy and astropy regions conflict

### DIFF
--- a/docs/changes/316.bugfix.rst
+++ b/docs/changes/316.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed conflict of gammapy<=2.1 with regions>=0.12 due to renamed function from regions imported in gammapy.regions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 
 [project.optional-dependencies]
 gammapy = [
-  "gammapy >=1.0,<2.1",
+  "gammapy >=1.0",
+  "regions <0.12"
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gammapy = [
-  "gammapy >=1.0",
+  "gammapy >=1.0,<2.1",
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 gammapy = [
   "gammapy >=1.0",
-  "regions <0.12"
+  "regions <0.12"  # gammapy uses function removed in 0.12, remove when fixed upstream
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
Up to the latest gammapy release at the time of writing (v2.1) `gammapy.regions` imports the function `pixel_scale_angle_at_skycoord` from astropy's `regions` package, which was removed/renamed in regions v0.12, see [here](https://github.com/gammapy/gammapy/blob/v2.1/gammapy/utils/regions.py#L32) for the relevant gammapy code, [here](https://github.com/astropy/regions/pull/650/changes#diff-99103805d4632d7b7570731408cd3e572b723f361998388ba904bc96fc20aa96) for the change in regions. `pyirf` uses gammapy code that imports this in `pyirf.conftest`.

As this breaks the CI for completely unrelated PRs I suggest to constrain regions to <0.12 for now, until the issue is fixed in Gammapy, which should already be the next release.