### PR TITLE
Fixed broken IRF interpolation due to removed numpy cross 2-component vector functionality

### DIFF
--- a/docs/changes/317.bugfix.rst
+++ b/docs/changes/317.bugfix.rst
@@ -1,0 +1,1 @@
+Changes `interpolation.utils.plumb_point_distance()` to fix `numpy.cross()` 2-component vector functionality removed in numpy>=2.5.

--- a/pyirf/interpolation/utils.py
+++ b/pyirf/interpolation/utils.py
@@ -62,6 +62,11 @@ def plumb_point_dist(line, target):
     ):
         # Compute distance of plumb point to line, for details see
         # https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Another_vector_formulation
+        if line.shape[1] == 2:
+            # Since numpy>=2.5 np.cross for 2 component vectors was completely removed
+            # Cross product of 2 component vectors a and b is equivalent to det([a,b])
+            mat = np.stack([P - A, B - A])
+            return np.linalg.norm(np.linalg.det(mat)) / np.linalg.norm(B - A)
         return np.linalg.norm(np.cross(P - A, B - A)) / np.linalg.norm(B - A)
     # If not, the nearest point A <= x <= B is one A and B, thus the searched distance
     # is the one to this nearest point


### PR DESCRIPTION
Numpy removed the 2-component vector cross product functionality from `numpy.cross` after it has been deprecated for a while, which causes the `plumb_point_dist` function to fail in this case.
This will cause CI to fail in completely unrelated PRs.

This fixes the issue by using the fact that the cross product of 2 vectors `a` and `b` in 2D is simply the determinant of the 2x2 matrix composed of `a` and `b`.

Another option would have been appending 0 to both vectors before using `np.cross()`. The last component of the resulting vector is then equivalent to the 2D cross product. However after a quick check showed that this is ~3x slower than the determinant method, see attached screenshot.

<img width="825" height="625" alt="Screenshot_20260709_115559" src="https://github.com/user-attachments/assets/3f66d426-3483-4922-a72e-20b6719ad60a" />
